### PR TITLE
Traverse rune trie

### DIFF
--- a/src/trie/rune_trie.go
+++ b/src/trie/rune_trie.go
@@ -68,6 +68,31 @@ func (t *RuneTrie) Insert(s string) {
 	}
 }
 
+// Traverse the keys of the trie. This will perform an approximately
+// lexicographical traversal, where digits will appear before alphabetical
+// characters, which will appear before symbols.
+func (t *RuneTrie) Traverse() <-chan string {
+	out := make(chan string)
+	go func() {
+		var dfs func(node *runeNode, prefix string)
+		dfs = func(n *runeNode, prefix string) {
+			if n == nil {
+				return
+			}
+			if n.end {
+				out <- prefix + n.char
+			}
+
+			for _, child := range n.children {
+				dfs(child, prefix+n.char)
+			}
+		}
+		dfs(t.root, "")
+		close(out)
+	}()
+	return out
+}
+
 // The children of each node are stored in a fixed size array of 51 elements
 // (since there are 51 total allowed characters in a HTTP header key, assuming
 // case insensitivity). This function will convert the character to the

--- a/src/trie/rune_trie_test.go
+++ b/src/trie/rune_trie_test.go
@@ -182,3 +182,62 @@ func TestContains(t *testing.T) {
 		})
 	}
 }
+
+func TestTraverse(t *testing.T) {
+	tests := []struct {
+		name   string
+		inputs []string
+		want   []string
+	}{
+		{
+			name:   "simple",
+			inputs: []string{"foo", "bar", "baz"},
+			want:   []string{"bar", "baz", "foo"},
+		},
+		{
+			name: "empty",
+		},
+		{
+			name:   "single element",
+			inputs: []string{"foo"},
+			want:   []string{"foo"},
+		},
+		{
+			name:   "handles duplicates",
+			inputs: []string{"foo", "bar", "foo", "foo", "bar"},
+			want:   []string{"bar", "foo"},
+		},
+		{
+			name:   "preserves original case",
+			inputs: []string{"foO", "FOO"},
+			want:   []string{"foO"},
+		},
+		{
+			name:   "multiple words with same prefix",
+			inputs: []string{"prefixed", "pref", "pre", "prefixes", "prefix"},
+			want:   []string{"pre", "pref", "prefix", "prefixed", "prefixes"},
+		},
+		{
+			name:   "symbols and digits sort correctly",
+			inputs: []string{"1foo", "!bar", "#baz", "foo"},
+			want:   []string{"1foo", "foo", "!bar", "#baz"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			trie := NewRuneTrie()
+			for _, s := range tc.inputs {
+				trie.Insert(s)
+			}
+
+			i := 0
+			for val := range trie.Traverse() {
+				if val != tc.want[i] {
+					t.Errorf(`trie @ %d = %#q, wanted %#q`, i, val, tc.want[i])
+				}
+				i++
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Summary
<!-- A high level summary of the changes, including any gotchas that the reviewer should watch out for when reviewing. -->

This PR adds approximate lexicographical traversal of a rune trie. This is achieved using channels and a DFS traversal. Additionally, the node now stores the original insertion character.

### Motivation
<!-- Why is this change necessary? This can be a link to a GitHub issue or reproduction steps for a bug etc. -->

In general it is useful to be able to traverse a trie. This will be used in header validation middleware that will be registered to every routeit server.

### Test plan
<!-- How did you test the changes? Are there edge cases you are missing or were unable to test? -->

- [x] Additional unit tests
