### PR TITLE
[TODO App] Lists API E2E

### DIFF
--- a/examples/todo/backend.go
+++ b/examples/todo/backend.go
@@ -11,6 +11,7 @@ import (
 
 func GetBackendServer(dbConn *sql.DB) *routeit.Server {
 	usersRepo := db.NewUsersRepository(dbConn)
+	listsRepo := db.NewTodoListRepository(dbConn)
 	srv := routeit.NewServer(routeit.ServerConfig{
 		Debug:                  false,
 		StrictClientAcceptance: true,
@@ -24,6 +25,10 @@ func GetBackendServer(dbConn *sql.DB) *routeit.Server {
 		"/login":    handlers.LoginHandler(usersRepo),
 		"/refresh":  handlers.RefreshTokenHandler(usersRepo),
 		"/register": handlers.RegisterUserHandler(usersRepo),
+	})
+	srv.RegisterRoutes(routeit.RouteRegistry{
+		"/lists":       handlers.ListsMultiHandler(listsRepo),
+		"/lists/:list": handlers.ListsIndividualHandler(listsRepo),
 	})
 	return srv
 }


### PR DESCRIPTION
### Summary
<!-- A high level summary of the changes, including any gotchas that the reviewer should watch out for when reviewing. -->

This PR builds on the previous PR - #11 - by linking the new handlers into the router for the server, meaning they are now reachable by code. New E2E tests are added using a `sqlite3` in-memory database to validate their behaviour once integrated.

### Motivation
<!-- Why is this change necessary? This can be a link to a GitHub issue or reproduction steps for a bug etc. -->

To allow the handlers to be reachable over the network from the client

### Test plan
<!-- How did you test the changes? Are there edge cases you are missing or were unable to test? -->

- [x] E2E tests
