### PR TITLE
[TODO App] Middleware to load items

### DIFF
--- a/examples/todo/backend.go
+++ b/examples/todo/backend.go
@@ -13,6 +13,7 @@ import (
 func GetBackendServer(dbConn *sql.DB) *routeit.Server {
 	usersRepo := db.NewUsersRepository(dbConn)
 	listsRepo := db.NewTodoListRepository(dbConn)
+	itemsRepo := db.NewTodoItemRepository(dbConn)
 	srv := routeit.NewServer(routeit.ServerConfig{
 		Debug:                  false,
 		StrictClientAcceptance: true,
@@ -23,6 +24,7 @@ func GetBackendServer(dbConn *sql.DB) *routeit.Server {
 		routeit.CorsMiddleware(routeit.DefaultCors()),
 		middleware.JwtMiddleware(usersRepo),
 		middleware.LoadListMiddleware(listsRepo),
+		middleware.LoadItemMiddleware(itemsRepo),
 	)
 	srv.RegisterRoutesUnderNamespace("/auth", routeit.RouteRegistry{
 		"/login":    handlers.LoginHandler(usersRepo),

--- a/examples/todo/middleware/items.go
+++ b/examples/todo/middleware/items.go
@@ -1,0 +1,38 @@
+package middleware
+
+import (
+	"strings"
+
+	"github.com/sktylr/routeit"
+	"github.com/sktylr/routeit/examples/todo/dao"
+	"github.com/sktylr/routeit/examples/todo/db"
+)
+
+func LoadItemMiddleware(repo *db.TodoItemRepository) routeit.Middleware {
+	return func(c routeit.Chain, rw *routeit.ResponseWriter, req *routeit.Request) error {
+		path := req.Path()
+		if !strings.HasPrefix(path, "/lists/") || !strings.Contains(path, "/items/") {
+			return c.Proceed(rw, req)
+		}
+
+		user, userOk := routeit.ContextValueAs[*dao.User](req, "user")
+		list, listOk := routeit.ContextValueAs[*dao.TodoList](req, "list")
+		id, _ := req.PathParam("item")
+
+		item, err := repo.GetById(req.Context(), id)
+		if err != nil {
+			return err
+		}
+
+		if !listOk || item.TodoListId != list.Id {
+			return routeit.ErrNotFound()
+		}
+
+		if !userOk || item.UserId != user.Id {
+			return routeit.ErrForbidden()
+		}
+
+		req.NewContextValue("item", item)
+		return c.Proceed(rw, req)
+	}
+}

--- a/examples/todo/middleware/items_test.go
+++ b/examples/todo/middleware/items_test.go
@@ -1,0 +1,167 @@
+package middleware
+
+import (
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/sktylr/routeit"
+	"github.com/sktylr/routeit/examples/todo/dao"
+	"github.com/sktylr/routeit/examples/todo/db"
+)
+
+func TestLoadItemMiddleware(t *testing.T) {
+	type expect struct {
+		proceed  bool
+		wantErr  error
+		itemId   string
+		saveItem bool
+	}
+	now := time.Now().UTC()
+	cases := []struct {
+		name       string
+		uri        string
+		listId     string
+		itemId     string
+		userId     string
+		setupMocks func(sqlmock.Sqlmock)
+		expect     expect
+	}{
+		{
+			name:   "item found and belongs to user and list",
+			uri:    "/lists/list-123/items/item-123",
+			listId: "list-123",
+			itemId: "item-123",
+			userId: "user-123",
+			setupMocks: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(`SELECT id, created, updated, user_id, list_id, name, status FROM items WHERE id = \?`).
+					WithArgs("item-123").
+					WillReturnRows(sqlmock.NewRows([]string{"id", "created", "updated", "user_id", "list_id", "name", "status"}).
+						AddRow("item-123", now, now, "user-123", "list-123", "buy milk", "PENDING"))
+			},
+			expect: expect{proceed: true, itemId: "item-123", saveItem: true},
+		},
+		{
+			name:   "item not found returns 404",
+			uri:    "/lists/list-123/items/item-404",
+			listId: "list-123",
+			itemId: "item-404",
+			userId: "user-123",
+			setupMocks: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(`SELECT id, created, updated, user_id, list_id, name, status FROM items WHERE id = \?`).
+					WithArgs("item-404").
+					WillReturnError(sql.ErrNoRows)
+			},
+			expect: expect{proceed: false, wantErr: db.ErrItemNotFound},
+		},
+		{
+			name:   "db error propagated",
+			uri:    "/lists/list-123/items/item-err",
+			listId: "list-123",
+			itemId: "item-err",
+			userId: "user-123",
+			setupMocks: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(`SELECT id, created, updated, user_id, list_id, name, status FROM items WHERE id = \?`).
+					WithArgs("item-err").
+					WillReturnError(errors.New("db down"))
+			},
+			expect: expect{proceed: false, wantErr: db.ErrDatabaseIssue},
+		},
+		{
+			name:   "item belongs to another list returns 404",
+			uri:    "/lists/list-123/items/item-123",
+			listId: "list-123",
+			itemId: "item-123",
+			userId: "user-123",
+			setupMocks: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(`SELECT id, created, updated, user_id, list_id, name, status FROM items WHERE id = \?`).
+					WithArgs("item-123").
+					WillReturnRows(sqlmock.NewRows([]string{"id", "created", "updated", "user_id", "list_id", "name", "status"}).
+						AddRow("item-123", now, now, "user-123", "other-list", "buy milk", "COMPLETED"))
+			},
+			expect: expect{proceed: false, wantErr: routeit.ErrNotFound()},
+		},
+		{
+			name:   "item belongs to another user returns 403",
+			uri:    "/lists/list-123/items/item-123",
+			listId: "list-123",
+			itemId: "item-123",
+			userId: "user-123",
+			setupMocks: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(`SELECT id, created, updated, user_id, list_id, name, status FROM items WHERE id = \?`).
+					WithArgs("item-123").
+					WillReturnRows(sqlmock.NewRows([]string{"id", "created", "updated", "user_id", "list_id", "name", "status"}).
+						AddRow("item-123", now, now, "other-user", "list-123", "buy milk", "PENDING"))
+			},
+			expect: expect{proceed: false, wantErr: routeit.ErrForbidden()},
+		},
+		{
+			name:       "path not under lists",
+			uri:        "/auth/register",
+			setupMocks: func(s sqlmock.Sqlmock) {},
+			expect:     expect{proceed: true, saveItem: false},
+		},
+		{
+			name:       "path under lists but not items",
+			uri:        "/lists/list-123",
+			setupMocks: func(s sqlmock.Sqlmock) {},
+			expect:     expect{proceed: true, saveItem: false},
+		},
+		{
+			name:       "path under lists but not individual items",
+			uri:        "/lists/list-123/items",
+			setupMocks: func(s sqlmock.Sqlmock) {},
+			expect:     expect{proceed: true, saveItem: false},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db.WithUnitTestConnection(t, func(sqlDB *sql.DB, mock sqlmock.Sqlmock) {
+				tc.setupMocks(mock)
+
+				repo := db.NewTodoItemRepository(sqlDB)
+				mw := LoadItemMiddleware(repo)
+
+				req := routeit.NewTestRequest(t, tc.uri, routeit.GET, routeit.TestRequestOptions{
+					PathParams: map[string]string{
+						"list": tc.listId,
+						"item": tc.itemId,
+					},
+				})
+				req.NewContextValue("user", &dao.User{Meta: dao.Meta{Id: tc.userId}})
+				if tc.listId != "" {
+					req.NewContextValue("list", &dao.TodoList{Meta: dao.Meta{Id: tc.listId}})
+				}
+
+				_, proceed, err := routeit.TestMiddleware(mw, req)
+
+				if tc.expect.wantErr == nil {
+					if err != nil {
+						t.Fatalf("unexpected error: %v", err)
+					}
+					if !proceed {
+						t.Errorf("expected middleware to proceed")
+					}
+					raw, ok := req.ContextValue("item")
+					if ok != tc.expect.saveItem {
+						t.Fatalf("expected middleware to save item to context")
+					}
+					got, ok := raw.(*dao.TodoItem)
+					if tc.expect.saveItem && (!ok || got.Id != tc.expect.itemId) {
+						t.Errorf("expected item id %s in context, got %+v", tc.expect.itemId, got)
+					}
+				} else {
+					if err == nil {
+						t.Fatal("expected error, got none")
+					}
+					if !errors.Is(err, tc.expect.wantErr) {
+						t.Fatalf(`error = %v, wanted %v`, err, tc.expect.wantErr)
+					}
+				}
+			})
+		})
+	}
+}

--- a/examples/todo/middleware/lists_test.go
+++ b/examples/todo/middleware/lists_test.go
@@ -67,7 +67,7 @@ func TestLoadListMiddleware(t *testing.T) {
 			expect: expect{proceed: false, wantErr: routeit.ErrForbidden()},
 		},
 		{
-			name:   "db error returns 503",
+			name:   "db error propagated",
 			uri:    "/lists/list-err",
 			listId: "list-err",
 			userId: "user-123",


### PR DESCRIPTION
### Summary
<!-- A high level summary of the changes, including any gotchas that the reviewer should watch out for when reviewing. -->

This PR is similar to a previous PR that added middleware to load lists from the DB on lookup (#13). Instead, in this PR we load a todo item from the database when we know the endpoint will involve looking the item up. The reason for this is it means we have centralised control over guardrails (such as restricting user access) and can keep the handlers leaner and only focusing on their unique behaviour.

### Motivation
<!-- Why is this change necessary? This can be a link to a GitHub issue or reproduction steps for a bug etc. -->

This keeps handlers leaner and reduces the likelihood of inconsistent behaviour on a given endpoint under different http methods.

### Test plan
<!-- How did you test the changes? Are there edge cases you are missing or were unable to test? -->

- [x] New unit tests
- [ ] The middleware is technically registered to the server, but not under use yet. Once those paths are added, it will be tested more rigorously E2E
