### PR TITLE
[TODO App] Query items for a list and user

### DIFF
--- a/examples/todo/db/lists.go
+++ b/examples/todo/db/lists.go
@@ -150,7 +150,7 @@ func (r *TodoListRepository) GetListsByUser(ctx context.Context, userId string, 
 	for rows.Next() {
 		var l dao.AggregateTodoList
 		if err := rows.Scan(&l.Id, &l.Created, &l.Updated, &l.UserId, &l.Name, &l.Description, &l.TotalItems, &l.CompletedItems); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: %v", ErrDatabaseIssue, err)
 		}
 		l.Items = []dao.TodoItem{}
 		listIds = append(listIds, l.Id)


### PR DESCRIPTION
### Summary
<!-- A high level summary of the changes, including any gotchas that the reviewer should watch out for when reviewing. -->

This PR adds a new method to the `TodoItemRepository` that looks up items for a given list and user. The reason for requiring user is it makes it easier and more reliable to use within an API handler since we can enforce that only a specific user's items are returned in the response. The query is paginated using limit and offset.

### Motivation
<!-- Why is this change necessary? This can be a link to a GitHub issue or reproduction steps for a bug etc. -->

To allow us to introduce a new API handler under the `GET /lists/<id>/items` route that will list all the items of the given list.

### Test plan
<!-- How did you test the changes? Are there edge cases you are missing or were unable to test? -->

- [x] New unit tests
