### PR TITLE
[TODO App] Fix failing API updates

### DIFF
--- a/examples/todo/db/items.go
+++ b/examples/todo/db/items.go
@@ -141,17 +141,9 @@ func (r *TodoItemRepository) UpdateName(ctx context.Context, id, newName string)
 		SET name = ?, updated = ?
 		WHERE id = ?
 	`
-	res, err := r.db.ExecContext(ctx, query, newName, time.Now(), id)
+	_, err := r.db.ExecContext(ctx, query, newName, time.Now(), id)
 	if err != nil {
 		return fmt.Errorf("%w: %v", ErrDatabaseIssue, err)
-	}
-
-	rowsAffected, err := res.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("%w: %v", ErrDatabaseIssue, err)
-	}
-	if rowsAffected == 0 {
-		return fmt.Errorf("%w [%s]", ErrItemNotFound, id)
 	}
 
 	return nil

--- a/examples/todo/db/items_test.go
+++ b/examples/todo/db/items_test.go
@@ -290,14 +290,13 @@ func TestUpdateName(t *testing.T) {
 		},
 		{
 			name:    "no rows affected",
-			id:      "item-missing",
+			id:      "item-123",
 			newName: "No change",
 			mockSetup: func(m sqlmock.Sqlmock) {
 				m.ExpectExec(`UPDATE items`).
-					WithArgs("No change", sqlmock.AnyArg(), "item-missing").
+					WithArgs("No change", sqlmock.AnyArg(), "item-123").
 					WillReturnResult(sqlmock.NewResult(0, 0))
 			},
-			wantErr: true,
 		},
 	}
 

--- a/examples/todo/db/lists.go
+++ b/examples/todo/db/lists.go
@@ -58,17 +58,9 @@ func (r *TodoListRepository) UpdateList(ctx context.Context, listId, name, descr
 		SET name = ?, description = ?, updated = ?
 		WHERE id = ?
 	`
-	res, err := r.db.ExecContext(ctx, query, name, description, now, listId)
+	_, err := r.db.ExecContext(ctx, query, name, description, now, listId)
 	if err != nil {
 		return nil, fmt.Errorf("%w [failed to update list]: %v", ErrDatabaseIssue, err)
-	}
-
-	rowsAffected, err := res.RowsAffected()
-	if err != nil {
-		return nil, fmt.Errorf("%w [failed to determine rows affected]: %v", ErrDatabaseIssue, err)
-	}
-	if rowsAffected == 0 {
-		return nil, fmt.Errorf("%w [%s]", ErrListNotFound, listId)
 	}
 
 	list := &dao.TodoList{

--- a/examples/todo/db/lists_test.go
+++ b/examples/todo/db/lists_test.go
@@ -99,18 +99,14 @@ func TestUpdateList(t *testing.T) {
 			},
 		},
 		{
-			name:    "list not found",
-			listId:  "missing-456",
-			newName: "Doesn't matter",
-			newDesc: "Nope",
+			name:    "no update required",
+			listId:  "list-123",
+			newName: "Same as",
+			newDesc: "before",
 			mockSetup: func(m sqlmock.Sqlmock) {
 				m.ExpectExec(`UPDATE lists`).
-					WithArgs("Doesn't matter", "Nope", sqlmock.AnyArg(), "missing-456").
+					WithArgs("Same as", "before", sqlmock.AnyArg(), "list-123").
 					WillReturnResult(sqlmock.NewResult(0, 0))
-			},
-			expectErr: true,
-			errCheck: func(err error) bool {
-				return errors.Is(err, ErrListNotFound)
 			},
 		},
 		{

--- a/examples/todo/handlers/lists_test.go
+++ b/examples/todo/handlers/lists_test.go
@@ -426,21 +426,6 @@ func TestListsIndividualHandler(t *testing.T) {
 				},
 			},
 			{
-				// This technically shouldn't happen due to the middleware we
-				// have but may happen in a race condition
-				name:   "list not found returns 404",
-				listId: "missing-list",
-				body:   []byte(`{"name":"Something","description":"Whatever"}`),
-				mockSetup: func(mock sqlmock.Sqlmock) {
-					mock.ExpectExec(regexp.QuoteMeta(`
-						UPDATE lists SET name = ?, description = ?, updated = ? WHERE id = ?
-					`)).
-						WithArgs("Something", "Whatever", sqlmock.AnyArg(), "list-123").
-						WillReturnResult(sqlmock.NewResult(0, 0))
-				},
-				wantErr: db.ErrListNotFound,
-			},
-			{
 				name:      "invalid JSON",
 				listId:    "list-123",
 				body:      []byte(`{"invalid-json"}`),


### PR DESCRIPTION
### Summary
<!-- A high level summary of the changes, including any gotchas that the reviewer should watch out for when reviewing. -->

MySQL optimises `UPDATE` queries to return "no rows affected" if the query does not change any rows. So if we receive a request to update an item (whose name is "Bread") to update its name to "Bread", MySQL will tell us no rows have been affected, even though the query executed successfully. By contrast, if the request told us to update the name to "Cheese", this would return "1 row affected". This was causing the update endpoints to sometimes return `404: Not Found` incorrectly. The solution is to remove the "rows affected" check altogether, which also simplifies some tests and the repositories in general.

### Motivation
<!-- Why is this change necessary? This can be a link to a GitHub issue or reproduction steps for a bug etc. -->

This fixes a misrepresentation in API responses that was causing the client to interpret successful request as having failed.

### Test plan
<!-- How did you test the changes? Are there edge cases you are missing or were unable to test? -->

- [x] Updated unit tests
- [x] Existing E2E tests pass
- [x] Browser E2E manual testing
