### PR TITLE
[Chore] Bump examples to v1.0.1

### DIFF
--- a/examples/errors/handling/go.mod
+++ b/examples/errors/handling/go.mod
@@ -2,7 +2,4 @@ module github.com/sktylr/routeit/examples/errors/handling
 
 go 1.24.4
 
-// Required while this is not published
-replace github.com/sktylr/routeit => ../../..
-
-require github.com/sktylr/routeit v0.0.0-00010101000000-000000000000
+require github.com/sktylr/routeit v1.0.1

--- a/examples/errors/handling/go.sum
+++ b/examples/errors/handling/go.sum
@@ -1,0 +1,2 @@
+github.com/sktylr/routeit v1.0.1 h1:oOY/Ifi8O5PsNH27H8vA4tSLvj7f8p+5jTDVclvqDbU=
+github.com/sktylr/routeit v1.0.1/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/errors/mapping/go.mod
+++ b/examples/errors/mapping/go.mod
@@ -2,7 +2,4 @@ module github.com/sktylr/routeit/examples/errors/mapping
 
 go 1.24.4
 
-// Required while this is not published
-replace github.com/sktylr/routeit => ../../..
-
-require github.com/sktylr/routeit v0.0.0-00010101000000-000000000000
+require github.com/sktylr/routeit v1.0.1

--- a/examples/errors/mapping/go.sum
+++ b/examples/errors/mapping/go.sum
@@ -1,0 +1,2 @@
+github.com/sktylr/routeit v1.0.1 h1:oOY/Ifi8O5PsNH27H8vA4tSLvj7f8p+5jTDVclvqDbU=
+github.com/sktylr/routeit v1.0.1/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/middleware/complex/go.mod
+++ b/examples/middleware/complex/go.mod
@@ -2,7 +2,4 @@ module github.com/sktylr/routeit/examples/middleware/complex
 
 go 1.24.4
 
-// Required while this is not published
-replace github.com/sktylr/routeit => ../../..
-
-require github.com/sktylr/routeit v0.0.0-00010101000000-000000000000
+require github.com/sktylr/routeit v1.0.1

--- a/examples/middleware/complex/go.sum
+++ b/examples/middleware/complex/go.sum
@@ -1,0 +1,2 @@
+github.com/sktylr/routeit v1.0.1 h1:oOY/Ifi8O5PsNH27H8vA4tSLvj7f8p+5jTDVclvqDbU=
+github.com/sktylr/routeit v1.0.1/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/middleware/cors/go.mod
+++ b/examples/middleware/cors/go.mod
@@ -2,7 +2,4 @@ module github.com/sktylr/routeit/examples/middleware/cors
 
 go 1.24.4
 
-// Required while this is not published
-replace github.com/sktylr/routeit => ../../..
-
-require github.com/sktylr/routeit v0.0.0-00010101000000-000000000000
+require github.com/sktylr/routeit v1.0.1

--- a/examples/middleware/cors/go.sum
+++ b/examples/middleware/cors/go.sum
@@ -1,0 +1,2 @@
+github.com/sktylr/routeit v1.0.1 h1:oOY/Ifi8O5PsNH27H8vA4tSLvj7f8p+5jTDVclvqDbU=
+github.com/sktylr/routeit v1.0.1/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/middleware/simple/go.mod
+++ b/examples/middleware/simple/go.mod
@@ -2,7 +2,4 @@ module github.com/sktylr/routeit/examples/middleware/simple
 
 go 1.24.4
 
-// Required while this is not published
-replace github.com/sktylr/routeit => ../../..
-
-require github.com/sktylr/routeit v0.0.0-00010101000000-000000000000
+require github.com/sktylr/routeit v1.0.1

--- a/examples/middleware/simple/go.sum
+++ b/examples/middleware/simple/go.sum
@@ -1,0 +1,2 @@
+github.com/sktylr/routeit v1.0.1 h1:oOY/Ifi8O5PsNH27H8vA4tSLvj7f8p+5jTDVclvqDbU=
+github.com/sktylr/routeit v1.0.1/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/routing/complex/go.mod
+++ b/examples/routing/complex/go.mod
@@ -2,7 +2,4 @@ module github.com/sktylr/routeit/examples/routing/complex
 
 go 1.24.4
 
-// Required while this is not published
-replace github.com/sktylr/routeit => ../../..
-
-require github.com/sktylr/routeit v0.0.0-00010101000000-000000000000
+require github.com/sktylr/routeit v1.0.1

--- a/examples/routing/complex/go.sum
+++ b/examples/routing/complex/go.sum
@@ -1,0 +1,2 @@
+github.com/sktylr/routeit v1.0.1 h1:oOY/Ifi8O5PsNH27H8vA4tSLvj7f8p+5jTDVclvqDbU=
+github.com/sktylr/routeit v1.0.1/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/routing/dynamic/go.mod
+++ b/examples/routing/dynamic/go.mod
@@ -2,7 +2,4 @@ module github.com/sktylr/routeit/examples/routing/dynamic
 
 go 1.24.4
 
-// Required while this is not published
-replace github.com/sktylr/routeit => ../../..
-
-require github.com/sktylr/routeit v0.0.0-00010101000000-000000000000
+require github.com/sktylr/routeit v1.0.1

--- a/examples/routing/dynamic/go.sum
+++ b/examples/routing/dynamic/go.sum
@@ -1,0 +1,2 @@
+github.com/sktylr/routeit v1.0.1 h1:oOY/Ifi8O5PsNH27H8vA4tSLvj7f8p+5jTDVclvqDbU=
+github.com/sktylr/routeit v1.0.1/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/routing/namespaced/go.mod
+++ b/examples/routing/namespaced/go.mod
@@ -2,7 +2,4 @@ module github.com/sktylr/routeit/examples/routing/namespaced
 
 go 1.24.4
 
-// Required while this is not published
-replace github.com/sktylr/routeit => ../../..
-
-require github.com/sktylr/routeit v0.0.0-00010101000000-000000000000
+require github.com/sktylr/routeit v1.0.1

--- a/examples/routing/namespaced/go.sum
+++ b/examples/routing/namespaced/go.sum
@@ -1,0 +1,2 @@
+github.com/sktylr/routeit v1.0.1 h1:oOY/Ifi8O5PsNH27H8vA4tSLvj7f8p+5jTDVclvqDbU=
+github.com/sktylr/routeit v1.0.1/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/routing/simple/go.mod
+++ b/examples/routing/simple/go.mod
@@ -2,7 +2,4 @@ module github.com/sktylr/routeit/examples/routing/simple
 
 go 1.24.4
 
-// Required while this is not published
-replace github.com/sktylr/routeit => ../../..
-
-require github.com/sktylr/routeit v0.0.0-00010101000000-000000000000
+require github.com/sktylr/routeit v1.0.1

--- a/examples/routing/simple/go.sum
+++ b/examples/routing/simple/go.sum
@@ -1,0 +1,2 @@
+github.com/sktylr/routeit v1.0.1 h1:oOY/Ifi8O5PsNH27H8vA4tSLvj7f8p+5jTDVclvqDbU=
+github.com/sktylr/routeit v1.0.1/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/simple/go.mod
+++ b/examples/simple/go.mod
@@ -2,7 +2,4 @@ module github.com/sktylr/routeit/examples/simple
 
 go 1.24.4
 
-// Required while this is not published
-replace github.com/sktylr/routeit => ../..
-
-require github.com/sktylr/routeit v0.0.0-00010101000000-000000000000
+require github.com/sktylr/routeit v1.0.1

--- a/examples/simple/go.sum
+++ b/examples/simple/go.sum
@@ -1,0 +1,2 @@
+github.com/sktylr/routeit v1.0.1 h1:oOY/Ifi8O5PsNH27H8vA4tSLvj7f8p+5jTDVclvqDbU=
+github.com/sktylr/routeit v1.0.1/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/static/rewrites/complex/go.mod
+++ b/examples/static/rewrites/complex/go.mod
@@ -2,7 +2,4 @@ module github.com/sktylr/routeit/examples/static/rewrites/complex
 
 go 1.24.4
 
-// Required while this is not published
-replace github.com/sktylr/routeit => ../../../..
-
-require github.com/sktylr/routeit v0.0.0-00010101000000-000000000000
+require github.com/sktylr/routeit v1.0.1

--- a/examples/static/rewrites/complex/go.sum
+++ b/examples/static/rewrites/complex/go.sum
@@ -1,0 +1,2 @@
+github.com/sktylr/routeit v1.0.1 h1:oOY/Ifi8O5PsNH27H8vA4tSLvj7f8p+5jTDVclvqDbU=
+github.com/sktylr/routeit v1.0.1/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/static/rewrites/dynamic/go.mod
+++ b/examples/static/rewrites/dynamic/go.mod
@@ -2,7 +2,4 @@ module github.com/sktylr/routeit/examples/static/rewrites/dynamic
 
 go 1.24.4
 
-// Required while this is not published
-replace github.com/sktylr/routeit => ../../../..
-
-require github.com/sktylr/routeit v0.0.0-00010101000000-000000000000
+require github.com/sktylr/routeit v1.0.1

--- a/examples/static/rewrites/dynamic/go.sum
+++ b/examples/static/rewrites/dynamic/go.sum
@@ -1,0 +1,2 @@
+github.com/sktylr/routeit v1.0.1 h1:oOY/Ifi8O5PsNH27H8vA4tSLvj7f8p+5jTDVclvqDbU=
+github.com/sktylr/routeit v1.0.1/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/static/rewrites/static/go.mod
+++ b/examples/static/rewrites/static/go.mod
@@ -2,7 +2,4 @@ module github.com/sktylr/routeit/examples/static/rewrites/static
 
 go 1.24.4
 
-// Required while this is not published
-replace github.com/sktylr/routeit => ../../../..
-
-require github.com/sktylr/routeit v0.0.0-00010101000000-000000000000
+require github.com/sktylr/routeit v1.0.1

--- a/examples/static/rewrites/static/go.sum
+++ b/examples/static/rewrites/static/go.sum
@@ -1,0 +1,2 @@
+github.com/sktylr/routeit v1.0.1 h1:oOY/Ifi8O5PsNH27H8vA4tSLvj7f8p+5jTDVclvqDbU=
+github.com/sktylr/routeit v1.0.1/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/static/simple/go.mod
+++ b/examples/static/simple/go.mod
@@ -2,7 +2,4 @@ module github.com/sktylr/routeit/examples/static/simple
 
 go 1.24.4
 
-// Required while this is not published
-replace github.com/sktylr/routeit => ../../..
-
-require github.com/sktylr/routeit v0.0.0-00010101000000-000000000000
+require github.com/sktylr/routeit v1.0.1

--- a/examples/static/simple/go.sum
+++ b/examples/static/simple/go.sum
@@ -1,0 +1,2 @@
+github.com/sktylr/routeit v1.0.1 h1:oOY/Ifi8O5PsNH27H8vA4tSLvj7f8p+5jTDVclvqDbU=
+github.com/sktylr/routeit v1.0.1/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/todo/go.mod
+++ b/examples/todo/go.mod
@@ -2,16 +2,13 @@ module github.com/sktylr/routeit/examples/todo
 
 go 1.24.4
 
-// Required while this is not published
-replace github.com/sktylr/routeit => ../..
-
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/google/uuid v1.6.0
 	github.com/mattn/go-sqlite3 v1.14.30
-	github.com/sktylr/routeit v0.0.0-00010101000000-000000000000
+	github.com/sktylr/routeit v1.0.1
 	golang.org/x/crypto v0.40.0
 )
 

--- a/examples/todo/go.sum
+++ b/examples/todo/go.sum
@@ -11,5 +11,7 @@ github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/mattn/go-sqlite3 v1.14.30 h1:bVreufq3EAIG1Quvws73du3/QgdeZ3myglJlrzSYYCY=
 github.com/mattn/go-sqlite3 v1.14.30/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
+github.com/sktylr/routeit v1.0.1 h1:oOY/Ifi8O5PsNH27H8vA4tSLvj7f8p+5jTDVclvqDbU=
+github.com/sktylr/routeit v1.0.1/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=
 golang.org/x/crypto v0.40.0 h1:r4x+VvoG5Fm+eJcxMaY8CQM7Lb0l1lsmjGBQ6s8BfKM=
 golang.org/x/crypto v0.40.0/go.mod h1:Qr1vMER5WyS2dfPHAlsOj01wgLbsyWtFn/aY+5+ZdxY=


### PR DESCRIPTION
### Summary
<!-- A high level summary of the changes, including any gotchas that the reviewer should watch out for when reviewing. -->

This PR bumps the dependency in all examples to v1.0.1. Since the package is now published to golang's package registry, we don't need to handle local package management and can instead rely on the package registry. This achieves this for all examples.

Commands run (per example project)
```bash
$ go get github.com/sktylr/routeit@v1.0.1
$ go mod tidy
```

### Motivation
<!-- Why is this change necessary? This can be a link to a GitHub issue or reproduction steps for a bug etc. -->

Since we have published v1.0.1, this brings the example projects to the same state they would be if they were not built next to the actual source.

### Test plan
<!-- How did you test the changes? Are there edge cases you are missing or were unable to test? -->

- [x] Existing tests and builds passed
