### PR TITLE
[Chore] Rewrite README

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,5 +1,5 @@
 ---
-name: routeit examples Build and Test
+name: examples
 "on": [push]
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
 ---
-name: routeit Build and Test
+name: routeit
 "on": [push]
 
 jobs:


### PR DESCRIPTION
### Summary
<!-- A high level summary of the changes, including any gotchas that the reviewer should watch out for when reviewing. -->

This change rewrites the README to be better suited to being hosted on `pkg.go.dev` by removing the story-like narrative and instead focusing on features and examples.

New badges are added to show the build status as well as point to `pkg.go.dev`. The builds have been renamed to remove `Build and Test` since it is redundant.

The README has been restructured to be more feature-focused and provided more examples on minimal setup

### Motivation
<!-- Why is this change necessary? This can be a link to a GitHub issue or reproduction steps for a bug etc. -->

🧹

### Test plan
<!-- How did you test the changes? Are there edge cases you are missing or were unable to test? -->

N/A.
