### PR TITLE
[Fix] Allow route registration on local namespace root

### DIFF
--- a/router.go
+++ b/router.go
@@ -103,10 +103,14 @@ func (r *router) RegisterRoutes(rreg RouteRegistry) {
 func (r *router) RegisterRoutesUnderNamespace(namespace string, rreg RouteRegistry) {
 	namespace = r.trimRouteForInsert(namespace)
 	for path, handler := range rreg {
-		if !strings.HasPrefix(path, "/") {
-			path = "/" + path
+		if path == "" || path == "/" {
+			r.routes.Insert(namespace, &handler)
+		} else {
+			if !strings.HasPrefix(path, "/") {
+				path = "/" + path
+			}
+			r.routes.Insert(namespace+path, &handler)
 		}
-		r.routes.Insert(namespace+path, &handler)
 	}
 }
 

--- a/router_test.go
+++ b/router_test.go
@@ -225,6 +225,25 @@ func TestRoute(t *testing.T) {
 				path:           "/foo/bazaqux",
 				wantPathParams: pathParameters{"bar": "bazaqux"},
 			},
+			{
+				name:       "at root (with slash) of local namespace",
+				reg:        RouteRegistry{"/": Get(wantHandler)},
+				path:       "/api",
+				lNamespace: "/api",
+			},
+			{
+				name:       "at root (no slash) of local namespace",
+				reg:        RouteRegistry{"": Get(wantHandler)},
+				path:       "/api",
+				lNamespace: "/api",
+			},
+			{
+				name:           "at root (with dynamic) of local namespace",
+				reg:            RouteRegistry{"/:foo": Get(wantHandler)},
+				path:           "/api/bar",
+				lNamespace:     "/api",
+				wantPathParams: pathParameters{"foo": "bar"},
+			},
 		}
 
 		for _, tc := range tests {


### PR DESCRIPTION
### Summary
<!-- A high level summary of the changes, including any gotchas that the reviewer should watch out for when reviewing. -->

This PR changes how routes are registered under a local namespace by removing the requirement to prefix with `/` if the route is empty or `/` already. In these cases, we register the namespace itself (no suffix), which ensures we can successfully route to this endpoint when requests come in.

### Motivation
<!-- Why is this change necessary? This can be a link to a GitHub issue or reproduction steps for a bug etc. -->

Previously, an attempt to register a root directly under a local namespace (example below), would always result in the route not being found. This is due to a bug where the router would register this route as `/api/`, meaning that after the trailing slash was stripped from the incoming request URI, it would fail to be found.

```go
srv.RegisterRoutesUnderNamespace("/api", routeit.RouteRegistry{
  "/": routeit.Get(/* ... */),
})
```

### Test plan
<!-- How did you test the changes? Are there edge cases you are missing or were unable to test? -->

- [x] Existing tests all pass
- [x] Newly introduced tests for this edge case pass
