### PR TITLE
[Chore] Bump examples to `v1.0.3`

### DIFF
--- a/examples/errors/handling/go.mod
+++ b/examples/errors/handling/go.mod
@@ -2,4 +2,4 @@ module github.com/sktylr/routeit/examples/errors/handling
 
 go 1.24.4
 
-require github.com/sktylr/routeit v1.0.2
+require github.com/sktylr/routeit v1.0.3

--- a/examples/errors/handling/go.sum
+++ b/examples/errors/handling/go.sum
@@ -1,2 +1,2 @@
-github.com/sktylr/routeit v1.0.2 h1:L7216xatiab8Q4SlwsqAKRpjvQljYxKm4l8m+TFJsBw=
-github.com/sktylr/routeit v1.0.2/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=
+github.com/sktylr/routeit v1.0.3 h1:h2C482sP48eKXzlwGmiBwtV34q76JQ2D6MSWBa2PvwQ=
+github.com/sktylr/routeit v1.0.3/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/errors/mapping/go.mod
+++ b/examples/errors/mapping/go.mod
@@ -2,4 +2,4 @@ module github.com/sktylr/routeit/examples/errors/mapping
 
 go 1.24.4
 
-require github.com/sktylr/routeit v1.0.2
+require github.com/sktylr/routeit v1.0.3

--- a/examples/errors/mapping/go.sum
+++ b/examples/errors/mapping/go.sum
@@ -1,2 +1,2 @@
-github.com/sktylr/routeit v1.0.2 h1:L7216xatiab8Q4SlwsqAKRpjvQljYxKm4l8m+TFJsBw=
-github.com/sktylr/routeit v1.0.2/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=
+github.com/sktylr/routeit v1.0.3 h1:h2C482sP48eKXzlwGmiBwtV34q76JQ2D6MSWBa2PvwQ=
+github.com/sktylr/routeit v1.0.3/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/middleware/complex/go.mod
+++ b/examples/middleware/complex/go.mod
@@ -2,4 +2,4 @@ module github.com/sktylr/routeit/examples/middleware/complex
 
 go 1.24.4
 
-require github.com/sktylr/routeit v1.0.2
+require github.com/sktylr/routeit v1.0.3

--- a/examples/middleware/complex/go.sum
+++ b/examples/middleware/complex/go.sum
@@ -1,2 +1,2 @@
-github.com/sktylr/routeit v1.0.2 h1:L7216xatiab8Q4SlwsqAKRpjvQljYxKm4l8m+TFJsBw=
-github.com/sktylr/routeit v1.0.2/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=
+github.com/sktylr/routeit v1.0.3 h1:h2C482sP48eKXzlwGmiBwtV34q76JQ2D6MSWBa2PvwQ=
+github.com/sktylr/routeit v1.0.3/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/middleware/cors/go.mod
+++ b/examples/middleware/cors/go.mod
@@ -2,4 +2,4 @@ module github.com/sktylr/routeit/examples/middleware/cors
 
 go 1.24.4
 
-require github.com/sktylr/routeit v1.0.2
+require github.com/sktylr/routeit v1.0.3

--- a/examples/middleware/cors/go.sum
+++ b/examples/middleware/cors/go.sum
@@ -1,2 +1,2 @@
-github.com/sktylr/routeit v1.0.2 h1:L7216xatiab8Q4SlwsqAKRpjvQljYxKm4l8m+TFJsBw=
-github.com/sktylr/routeit v1.0.2/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=
+github.com/sktylr/routeit v1.0.3 h1:h2C482sP48eKXzlwGmiBwtV34q76JQ2D6MSWBa2PvwQ=
+github.com/sktylr/routeit v1.0.3/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/middleware/simple/go.mod
+++ b/examples/middleware/simple/go.mod
@@ -2,4 +2,4 @@ module github.com/sktylr/routeit/examples/middleware/simple
 
 go 1.24.4
 
-require github.com/sktylr/routeit v1.0.2
+require github.com/sktylr/routeit v1.0.3

--- a/examples/middleware/simple/go.sum
+++ b/examples/middleware/simple/go.sum
@@ -1,2 +1,2 @@
-github.com/sktylr/routeit v1.0.2 h1:L7216xatiab8Q4SlwsqAKRpjvQljYxKm4l8m+TFJsBw=
-github.com/sktylr/routeit v1.0.2/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=
+github.com/sktylr/routeit v1.0.3 h1:h2C482sP48eKXzlwGmiBwtV34q76JQ2D6MSWBa2PvwQ=
+github.com/sktylr/routeit v1.0.3/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/routing/complex/go.mod
+++ b/examples/routing/complex/go.mod
@@ -2,4 +2,4 @@ module github.com/sktylr/routeit/examples/routing/complex
 
 go 1.24.4
 
-require github.com/sktylr/routeit v1.0.2
+require github.com/sktylr/routeit v1.0.3

--- a/examples/routing/complex/go.sum
+++ b/examples/routing/complex/go.sum
@@ -1,2 +1,2 @@
-github.com/sktylr/routeit v1.0.2 h1:L7216xatiab8Q4SlwsqAKRpjvQljYxKm4l8m+TFJsBw=
-github.com/sktylr/routeit v1.0.2/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=
+github.com/sktylr/routeit v1.0.3 h1:h2C482sP48eKXzlwGmiBwtV34q76JQ2D6MSWBa2PvwQ=
+github.com/sktylr/routeit v1.0.3/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/routing/dynamic/go.mod
+++ b/examples/routing/dynamic/go.mod
@@ -2,4 +2,4 @@ module github.com/sktylr/routeit/examples/routing/dynamic
 
 go 1.24.4
 
-require github.com/sktylr/routeit v1.0.2
+require github.com/sktylr/routeit v1.0.3

--- a/examples/routing/dynamic/go.sum
+++ b/examples/routing/dynamic/go.sum
@@ -1,2 +1,2 @@
-github.com/sktylr/routeit v1.0.2 h1:L7216xatiab8Q4SlwsqAKRpjvQljYxKm4l8m+TFJsBw=
-github.com/sktylr/routeit v1.0.2/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=
+github.com/sktylr/routeit v1.0.3 h1:h2C482sP48eKXzlwGmiBwtV34q76JQ2D6MSWBa2PvwQ=
+github.com/sktylr/routeit v1.0.3/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/routing/namespaced/go.mod
+++ b/examples/routing/namespaced/go.mod
@@ -2,4 +2,4 @@ module github.com/sktylr/routeit/examples/routing/namespaced
 
 go 1.24.4
 
-require github.com/sktylr/routeit v1.0.2
+require github.com/sktylr/routeit v1.0.3

--- a/examples/routing/namespaced/go.sum
+++ b/examples/routing/namespaced/go.sum
@@ -1,2 +1,2 @@
-github.com/sktylr/routeit v1.0.2 h1:L7216xatiab8Q4SlwsqAKRpjvQljYxKm4l8m+TFJsBw=
-github.com/sktylr/routeit v1.0.2/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=
+github.com/sktylr/routeit v1.0.3 h1:h2C482sP48eKXzlwGmiBwtV34q76JQ2D6MSWBa2PvwQ=
+github.com/sktylr/routeit v1.0.3/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/routing/simple/go.mod
+++ b/examples/routing/simple/go.mod
@@ -2,4 +2,4 @@ module github.com/sktylr/routeit/examples/routing/simple
 
 go 1.24.4
 
-require github.com/sktylr/routeit v1.0.2
+require github.com/sktylr/routeit v1.0.3

--- a/examples/routing/simple/go.sum
+++ b/examples/routing/simple/go.sum
@@ -1,2 +1,2 @@
-github.com/sktylr/routeit v1.0.2 h1:L7216xatiab8Q4SlwsqAKRpjvQljYxKm4l8m+TFJsBw=
-github.com/sktylr/routeit v1.0.2/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=
+github.com/sktylr/routeit v1.0.3 h1:h2C482sP48eKXzlwGmiBwtV34q76JQ2D6MSWBa2PvwQ=
+github.com/sktylr/routeit v1.0.3/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/simple/go.mod
+++ b/examples/simple/go.mod
@@ -2,4 +2,4 @@ module github.com/sktylr/routeit/examples/simple
 
 go 1.24.4
 
-require github.com/sktylr/routeit v1.0.2
+require github.com/sktylr/routeit v1.0.3

--- a/examples/simple/go.sum
+++ b/examples/simple/go.sum
@@ -1,2 +1,2 @@
-github.com/sktylr/routeit v1.0.2 h1:L7216xatiab8Q4SlwsqAKRpjvQljYxKm4l8m+TFJsBw=
-github.com/sktylr/routeit v1.0.2/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=
+github.com/sktylr/routeit v1.0.3 h1:h2C482sP48eKXzlwGmiBwtV34q76JQ2D6MSWBa2PvwQ=
+github.com/sktylr/routeit v1.0.3/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/static/rewrites/complex/go.mod
+++ b/examples/static/rewrites/complex/go.mod
@@ -2,4 +2,4 @@ module github.com/sktylr/routeit/examples/static/rewrites/complex
 
 go 1.24.4
 
-require github.com/sktylr/routeit v1.0.2
+require github.com/sktylr/routeit v1.0.3

--- a/examples/static/rewrites/complex/go.sum
+++ b/examples/static/rewrites/complex/go.sum
@@ -1,2 +1,2 @@
-github.com/sktylr/routeit v1.0.2 h1:L7216xatiab8Q4SlwsqAKRpjvQljYxKm4l8m+TFJsBw=
-github.com/sktylr/routeit v1.0.2/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=
+github.com/sktylr/routeit v1.0.3 h1:h2C482sP48eKXzlwGmiBwtV34q76JQ2D6MSWBa2PvwQ=
+github.com/sktylr/routeit v1.0.3/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/static/rewrites/dynamic/go.mod
+++ b/examples/static/rewrites/dynamic/go.mod
@@ -2,4 +2,4 @@ module github.com/sktylr/routeit/examples/static/rewrites/dynamic
 
 go 1.24.4
 
-require github.com/sktylr/routeit v1.0.2
+require github.com/sktylr/routeit v1.0.3

--- a/examples/static/rewrites/dynamic/go.sum
+++ b/examples/static/rewrites/dynamic/go.sum
@@ -1,2 +1,2 @@
-github.com/sktylr/routeit v1.0.2 h1:L7216xatiab8Q4SlwsqAKRpjvQljYxKm4l8m+TFJsBw=
-github.com/sktylr/routeit v1.0.2/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=
+github.com/sktylr/routeit v1.0.3 h1:h2C482sP48eKXzlwGmiBwtV34q76JQ2D6MSWBa2PvwQ=
+github.com/sktylr/routeit v1.0.3/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/static/rewrites/static/go.mod
+++ b/examples/static/rewrites/static/go.mod
@@ -2,4 +2,4 @@ module github.com/sktylr/routeit/examples/static/rewrites/static
 
 go 1.24.4
 
-require github.com/sktylr/routeit v1.0.2
+require github.com/sktylr/routeit v1.0.3

--- a/examples/static/rewrites/static/go.sum
+++ b/examples/static/rewrites/static/go.sum
@@ -1,2 +1,2 @@
-github.com/sktylr/routeit v1.0.2 h1:L7216xatiab8Q4SlwsqAKRpjvQljYxKm4l8m+TFJsBw=
-github.com/sktylr/routeit v1.0.2/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=
+github.com/sktylr/routeit v1.0.3 h1:h2C482sP48eKXzlwGmiBwtV34q76JQ2D6MSWBa2PvwQ=
+github.com/sktylr/routeit v1.0.3/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/static/simple/go.mod
+++ b/examples/static/simple/go.mod
@@ -2,4 +2,4 @@ module github.com/sktylr/routeit/examples/static/simple
 
 go 1.24.4
 
-require github.com/sktylr/routeit v1.0.2
+require github.com/sktylr/routeit v1.0.3

--- a/examples/static/simple/go.sum
+++ b/examples/static/simple/go.sum
@@ -1,2 +1,2 @@
-github.com/sktylr/routeit v1.0.2 h1:L7216xatiab8Q4SlwsqAKRpjvQljYxKm4l8m+TFJsBw=
-github.com/sktylr/routeit v1.0.2/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=
+github.com/sktylr/routeit v1.0.3 h1:h2C482sP48eKXzlwGmiBwtV34q76JQ2D6MSWBa2PvwQ=
+github.com/sktylr/routeit v1.0.3/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/todo/backend.go
+++ b/examples/todo/backend.go
@@ -37,10 +37,12 @@ func GetBackendServer(dbConn *sql.DB) *routeit.Server {
 		"/register": handlers.RegisterUserHandler(usersRepo),
 	})
 	srv.RegisterRoutes(routeit.RouteRegistry{
-		"/lists":                   handlers.ListsMultiHandler(listsRepo),
-		"/lists/:list":             handlers.ListsIndividualHandler(listsRepo),
-		"/lists/:list/items":       handlers.ItemsMultiHandler(itemsRepo),
-		"/lists/:list/items/:item": handlers.ItemsIndividualHandler(itemsRepo),
+		"/lists": handlers.ListsMultiHandler(listsRepo),
+	})
+	srv.RegisterRoutesUnderNamespace("/lists/:list", routeit.RouteRegistry{
+		"/":            handlers.ListsIndividualHandler(listsRepo),
+		"/items":       handlers.ItemsMultiHandler(itemsRepo),
+		"/items/:item": handlers.ItemsIndividualHandler(itemsRepo),
 	})
 	return srv
 }

--- a/examples/todo/go.mod
+++ b/examples/todo/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/google/uuid v1.6.0
 	github.com/mattn/go-sqlite3 v1.14.30
-	github.com/sktylr/routeit v1.0.2
+	github.com/sktylr/routeit v1.0.3
 	golang.org/x/crypto v0.40.0
 )
 

--- a/examples/todo/go.sum
+++ b/examples/todo/go.sum
@@ -11,7 +11,7 @@ github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/mattn/go-sqlite3 v1.14.30 h1:bVreufq3EAIG1Quvws73du3/QgdeZ3myglJlrzSYYCY=
 github.com/mattn/go-sqlite3 v1.14.30/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
-github.com/sktylr/routeit v1.0.2 h1:L7216xatiab8Q4SlwsqAKRpjvQljYxKm4l8m+TFJsBw=
-github.com/sktylr/routeit v1.0.2/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=
+github.com/sktylr/routeit v1.0.3 h1:h2C482sP48eKXzlwGmiBwtV34q76JQ2D6MSWBa2PvwQ=
+github.com/sktylr/routeit v1.0.3/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=
 golang.org/x/crypto v0.40.0 h1:r4x+VvoG5Fm+eJcxMaY8CQM7Lb0l1lsmjGBQ6s8BfKM=
 golang.org/x/crypto v0.40.0/go.mod h1:Qr1vMER5WyS2dfPHAlsOj01wgLbsyWtFn/aY+5+ZdxY=


### PR DESCRIPTION
### Summary
<!-- A high level summary of the changes, including any gotchas that the reviewer should watch out for when reviewing. -->

Per the title.

Changes have also been made to the routing configuration in `examples/todo` as a result of fixes made in `v1.0.3`. This makes it easier to understand routes for the lists and makes it less error prone by ensuring all the prefixes remain the same.

### Motivation
<!-- Why is this change necessary? This can be a link to a GitHub issue or reproduction steps for a bug etc. -->

Keep up to date.

### Test plan
<!-- How did you test the changes? Are there edge cases you are missing or were unable to test? -->

- [x] Existing tests pass
