### PR TITLE
Store request IDs

### DIFF
--- a/config.go
+++ b/config.go
@@ -102,6 +102,14 @@ type ServerConfig struct {
 	// Use [LogAttrExtractor] to include additional metadata in the default
 	// request line that is dumped for all incoming requests.
 	LogAttrExtractor LogAttrExtractor
+	// Use [RequestIdProvider] to tag each incoming request with an ID. This
+	// will automatically be logged and will be included as the "X-Request-Id"
+	// header in the response.
+	RequestIdProvider RequestIdProvider
+	// The header that each request ID is given in the response. This will
+	// default to "X-Request-Id" if [ServerConfig.RequestIdProvider] is
+	// non-nil. Otherwise, the header value will be ignored.
+	RequestIdHeader string
 }
 
 // The internal server config, which only stores the necessary values

--- a/logging.go
+++ b/logging.go
@@ -82,6 +82,7 @@ func (l *logger) attrs(rw *ResponseWriter, req *Request) []slog.Attr {
 		slog.Int("status", int(rw.s.code)),
 		slog.String("user_agent", req.userAgent),
 		slog.String("client_ip", req.ip),
+		slog.String("request_id", req.id),
 	}
 	return append(base, l.extraAttrs(req, rw.s)...)
 }

--- a/request.go
+++ b/request.go
@@ -33,6 +33,7 @@ type Request struct {
 	userAgent string
 	ip        string
 	accept    []ContentType
+	id        string
 }
 
 type HttpMethod struct {
@@ -198,6 +199,12 @@ func (req *Request) UserAgent() string {
 // The client's IP address that established connection with the server
 func (req *Request) ClientIP() string {
 	return req.ip
+}
+
+// The ID of the request. This will only be populated if an implementation is
+// provided to [ServerConfig.RequestIdProvider].
+func (req *Request) Id() string {
+	return req.id
 }
 
 // Access the query parameters of the request URI. This will always return a

--- a/request_id_middleware.go
+++ b/request_id_middleware.go
@@ -1,0 +1,24 @@
+package routeit
+
+// A [RequestIdProvider] is used to provide each incoming request with an ID.
+// Each valid request that reaches the server will be tagged with an ID
+// returned from this function. The resultant ID will be available on the
+// request using [Request.Id].
+type RequestIdProvider func(*Request) string
+
+// This middleware adds a request ID to each incoming request. When installed
+// to the server, it is installed after all other built-in middlewares. The
+// request ID is also added to each response using a header, which can help
+// with debugging. This header defaults to "X-Request-Id", but can be
+// customised.
+func requestIdMiddleware(prov RequestIdProvider, header string) Middleware {
+	if header == "" {
+		header = "X-Request-Id"
+	}
+
+	return func(c Chain, rw *ResponseWriter, req *Request) error {
+		req.id = prov(req)
+		rw.Headers().Set(header, req.id)
+		return c.Proceed(rw, req)
+	}
+}

--- a/request_id_middleware_test.go
+++ b/request_id_middleware_test.go
@@ -1,0 +1,56 @@
+package routeit
+
+import "testing"
+
+func TestRequestIdMiddleware(t *testing.T) {
+	tests := []struct {
+		name       string
+		header     string
+		provider   RequestIdProvider
+		wantId     string
+		wantHeader string
+	}{
+		{
+			name:       "no header provided, uses default",
+			provider:   func(r *Request) string { return "id" },
+			wantId:     "id",
+			wantHeader: "X-Request-Id",
+		},
+		{
+			name:       "uses custom header",
+			header:     "X-My-Request-Id",
+			provider:   func(r *Request) string { return "id" },
+			wantId:     "id",
+			wantHeader: "X-My-Request-Id",
+		},
+		{
+			name:   "uses provider correctly",
+			header: "With-Provider",
+			provider: func(r *Request) string {
+				return r.Path()
+			},
+			wantId:     "/foo",
+			wantHeader: "With-Provider",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mware := requestIdMiddleware(tc.provider, tc.header)
+			req := NewTestRequest(t, "/foo", GET, TestRequestOptions{})
+
+			res, proceeded, err := TestMiddleware(mware, req)
+
+			if err != nil {
+				t.Errorf(`err = %v, wanted nil`, err)
+			}
+			if !proceeded {
+				t.Error("did not proceed")
+			}
+			if req.req.id != tc.wantId {
+				t.Errorf(`id = %+q, wanted %+q`, req.req.id, tc.wantId)
+			}
+			res.AssertHeaderMatchesString(t, tc.wantHeader, tc.wantId)
+		})
+	}
+}

--- a/server.go
+++ b/server.go
@@ -47,6 +47,9 @@ func NewServer(conf ServerConfig) *Server {
 	if conf.AllowTraceRequests {
 		s.RegisterMiddleware(allowTraceValidationMiddleware())
 	}
+	if conf.RequestIdProvider != nil {
+		s.RegisterMiddleware(requestIdMiddleware(conf.RequestIdProvider, conf.RequestIdHeader))
+	}
 	return s
 }
 


### PR DESCRIPTION
### Summary
<!-- A high level summary of the changes, including any gotchas that the reviewer should watch out for when reviewing. -->

This PR allows inclusion of ID's on each incoming request. This is done through a piece of middleware that is conditionally installed to the server. We also include the request ID in a response header, which is defaulted to `"X-Request-Id"` but can be changed.

### Motivation
<!-- Why is this change necessary? This can be a link to a GitHub issue or reproduction steps for a bug etc. -->

This improves debugging by adding allowing users to add identifiers to incoming requests.

### Test plan
<!-- How did you test the changes? Are there edge cases you are missing or were unable to test? -->

- [x] Unit tests

This is not used anywhere yet but will be once the next version bump is published.
