### PR TITLE
UUIDv7 request ID

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,11 +5,19 @@ name: routeit
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    strategy:
+        matrix:
+            pkg:
+                - "."
+                - requestid
+
     steps:
       - uses: actions/checkout@v4
 
       - name: Get Go version
         id: get_version
+        working-directory: ${{ matrix.pkg }}
         run: echo "go_version=$(grep '^go ' go.mod | awk '{print $2}')" >> "$GITHUB_OUTPUT"
 
       - name: Set up Go
@@ -18,7 +26,9 @@ jobs:
           go-version: ${{ steps.get_version.outputs.go_version }}
 
       - name: Build
+        working-directory: ${{ matrix.pkg }}
         run: go build -v ./...
 
       - name: Test
+        working-directory: ${{ matrix.pkg }}
         run: go test -v ./...

--- a/requestid/README.md
+++ b/requestid/README.md
@@ -1,0 +1,32 @@
+## routeit/requestid
+
+`requestid` is a package under the [`routeit`](https://github.com/sktylr/routeit) module.
+`routeit` allows users to define `RequestIdProvider`s that generate an ID for incoming requests.
+
+This package provides a convenient implementation using V7 UUIDs.
+
+### Example usage
+
+```go
+package main
+
+import "github.com/sktylr/routeit"
+
+type HelloWorld struct {
+	Hello string `json:"hello"`
+}
+
+func main() {
+	srv := routeit.NewServer(routeit.ServerConfig{
+		Debug: true,
+		RequestIdProvider: requestid.NewUuidV7Provider(),
+	})
+	srv.RegisterRoutes(routeit.RouteRegistry{
+		"/hello": routeit.Get(func(rw *routeit.ResponseWriter, req *routeit.Request) error {
+			body := HelloWorld{Hello: "World"}
+			return rw.Json(body)
+		}),
+	})
+	srv.StartOrPanic()
+}
+```

--- a/requestid/doc.go
+++ b/requestid/doc.go
@@ -1,0 +1,10 @@
+// Package requestid is a convenience package that allows a user to register
+// UUID request ID's to each incoming request in a routeit server.
+//
+// # Copyright (c) 2025 Sam Taylor
+//
+// Licensed under the MIT License. You may obtain a copy of the License at
+// https://opensource.org/licenses/MIT
+//
+// This package provides UUIDv7 support for request ID's
+package requestid

--- a/requestid/go.mod
+++ b/requestid/go.mod
@@ -4,5 +4,5 @@ go 1.24.4
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/sktylr/routeit v1.0.3
+	github.com/sktylr/routeit v1.1.0
 )

--- a/requestid/go.mod
+++ b/requestid/go.mod
@@ -1,0 +1,8 @@
+module github.com/sktylr/routeit/requestid
+
+go 1.24.4
+
+require (
+	github.com/google/uuid v1.6.0
+	github.com/sktylr/routeit v1.0.3
+)

--- a/requestid/go.sum
+++ b/requestid/go.sum
@@ -2,3 +2,5 @@ github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/sktylr/routeit v1.0.3 h1:h2C482sP48eKXzlwGmiBwtV34q76JQ2D6MSWBa2PvwQ=
 github.com/sktylr/routeit v1.0.3/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=
+github.com/sktylr/routeit v1.1.0 h1:lvTSylfZJ8noqp1bkKs89We2TlXWBO3J2+RjZ3UK5HU=
+github.com/sktylr/routeit v1.1.0/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/requestid/go.sum
+++ b/requestid/go.sum
@@ -1,0 +1,4 @@
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/sktylr/routeit v1.0.3 h1:h2C482sP48eKXzlwGmiBwtV34q76JQ2D6MSWBa2PvwQ=
+github.com/sktylr/routeit v1.0.3/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/requestid/request_id.go
+++ b/requestid/request_id.go
@@ -1,0 +1,25 @@
+package requestid
+
+import (
+	"github.com/google/uuid"
+	"github.com/sktylr/routeit"
+)
+
+// Returns a [routeit.RequestIdProvider] that returns a UUIDv7 ID for each
+// request. UUIDv7 ID's are guaranteed to be ordered by creation, meaning
+// request ID's can be traced more accurately and easily to understand the
+// order of request receipt. In the case where the ID cannot be generated, an
+// empty string is returned as we do not wish to block the request lifecycle
+// purely because a debug identifier cannot be attached to the request.
+func NewUuidV7Provider() routeit.RequestIdProvider {
+	return func(r *routeit.Request) string {
+		id, err := uuid.NewV7()
+		if err != nil {
+			// Request IDs are nice to have, but not essential. We shouldn't
+			// block the request just because we couldn't generate an ID for it
+			return ""
+		}
+
+		return id.String()
+	}
+}

--- a/requestid/request_id_test.go
+++ b/requestid/request_id_test.go
@@ -1,0 +1,37 @@
+package requestid
+
+import (
+	"regexp"
+	"slices"
+	"testing"
+
+	"github.com/sktylr/routeit"
+)
+
+func TestUuidV7(t *testing.T) {
+	prov := NewUuidV7Provider()
+
+	t.Run("generates UUID", func(t *testing.T) {
+		regex := regexp.MustCompile(
+			"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
+		)
+
+		id := prov(&routeit.Request{})
+
+		if !regex.MatchString(id) {
+			t.Errorf(`id = %#q, does not match UUID regex`, id)
+		}
+	})
+
+	t.Run("guarantees order by creation", func(t *testing.T) {
+		id1 := prov(&routeit.Request{})
+		id2 := prov(&routeit.Request{})
+
+		if id1 == id2 {
+			t.Errorf(`id1 = %#q, id2 = %#q, should not equal`, id1, id2)
+		}
+		if !slices.IsSorted([]string{id1, id2}) {
+			t.Errorf(`id1 = %#q, id2 = %#q, not in order`, id1, id2)
+		}
+	})
+}


### PR DESCRIPTION
### Summary
<!-- A high level summary of the changes, including any gotchas that the reviewer should watch out for when reviewing. -->

This PR adds a new package - `github.com/sktylr/routeit/requestid` that currently exposes 1 method: `NewUuidV7Provider`, which returns a request ID provider that attaches a v7 UUID to each request. In the case that the ID cannot be generated, we don't return the error nor panic, as there is no reason to block the request, it will just proceed without any debug ID.

This package is included as a separate module under `routeit`. I have left it this way for dependency management, but may change that in the future.

### Motivation
<!-- Why is this change necessary? This can be a link to a GitHub issue or reproduction steps for a bug etc. -->

This provides a "normal" implementation that reduces the need for integrators to develop their own version of this.

### Test plan
<!-- How did you test the changes? Are there edge cases you are missing or were unable to test? -->

- [x] Unit tests
