### PR TITLE
Register request id middleware immediately after timeout middleware

### DIFF
--- a/header_validation_middleware.go
+++ b/header_validation_middleware.go
@@ -2,7 +2,8 @@ package routeit
 
 import "github.com/sktylr/routeit/internal/trie"
 
-// This middleware is the second piece of middleware run on all server
+// This middleware is the second (or third, if request ID's are assigned to
+// each incoming request) piece of middleware run on all server
 // instances. It will block requests that illegally contain repeated header
 // values. Some of the headers that are blocked are blocked for security
 // reasons (e.g. multiple "Authorization" headers poses a security risk), while

--- a/host_middleware.go
+++ b/host_middleware.go
@@ -7,8 +7,9 @@ import (
 	"github.com/sktylr/routeit/internal/cmp"
 )
 
-// Middleware that is always registered as the third piece of middleware for
-// the server, and rejects all incoming requests that do not match the server's
+// Middleware that is always registered as the third (or fourth, if the server
+// assigns request ID's to each incoming request) piece of middleware for the
+// server, and rejects all incoming requests that do not match the server's
 // expected Host header pattern. Per RFC-9112 Sec 7.2, the server MUST reject
 // the request and return 400: Bad Request when it does not contain a Host
 // header. We do the same when the Host header does not match any expected


### PR DESCRIPTION
### Summary
<!-- A high level summary of the changes, including any gotchas that the reviewer should watch out for when reviewing. -->

This PR changes the order in which built-in middleware is registered to the server. Now, the middleware that assigns a request ID is registered immediately after the timeout middleware (so long as the server has request ID's configured), as opposed to after all other built-in middleware. This is a non-breaking change and only changes the internal semantics. In reality, a well-formed request should not be blocked by any built-in middleware, so should have proceeded to the request ID middleware, however for consistency it is better that this change is made.

### Motivation
<!-- Why is this change necessary? This can be a link to a GitHub issue or reproduction steps for a bug etc. -->

Previously, logs would be inconsistent, as there might be some requests that have invalid hosts or improper header semantics that would be rejected by the built-in middleware. In such cases, an empty request ID would be logged for the request, due to the middleware circuit breaking before the request was assigned an ID. This is undesirable as it can cause confusion and will also make it harder to debug why requests failed.

### Test plan
<!-- How did you test the changes? Are there edge cases you are missing or were unable to test? -->

- [x] Existing tests
