### PR TITLE
[https] Combined socket for TLS and TCP

### DIFF
--- a/internal/socket/combined.go
+++ b/internal/socket/combined.go
@@ -1,0 +1,67 @@
+package socket
+
+import ctls "crypto/tls"
+
+// A [combined] socket is one that holds two TCP connections. The first serves
+// and receives messages directly over TCP, while the second uses TLS over TCP
+// for increased security. It is typically used when we would want to listen
+// for HTTP and HTTPS messages, as the former will travel directly over TCP,
+// while the latter will be transported via TLS over TCP.
+type combined struct {
+	tcp Socket
+	tls Socket
+}
+
+// Use [NewCombinedSocket] to listen over two separate ports, listening over
+// TCP on the first and TLS over TCP on the second. A valid, non-nil
+// [ctls.Config] must be passed and the ports must be different, otherwise
+// calling [Socket.Bind] will fail.
+func NewCombinedSocket(tcpPort, tlsPort uint16, conf *ctls.Config) Socket {
+	return &combined{
+		tcp: NewTcpSocket(tcpPort),
+		tls: NewTlsSocket(tlsPort, conf),
+	}
+}
+
+func (c *combined) Bind() error {
+	if err := c.tcp.Bind(); err != nil {
+		return err
+	}
+	if err := c.tls.Bind(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *combined) Serve(onConn onConnection, onErr onError) {
+	ch := make(chan struct{}, 2)
+
+	go func() {
+		c.tcp.Serve(onConn, onErr)
+		ch <- struct{}{}
+	}()
+	go func() {
+		c.tls.Serve(onConn, onErr)
+		ch <- struct{}{}
+	}()
+
+	// The individual [Socket.Serve] implementations for TCP and TLS are
+	// blocking. Since we spin up two separate go-routines for this here, we
+	// end up making this implementation non-blocking. For consistency, we use
+	// channels within the go-routines so that if both underlying sockets
+	// become closed (i.e. using the [Socket.Close] method), then we will exit
+	// this method, otherwise we will block as is done on the underlying
+	// sockets.
+	<-ch
+	<-ch
+}
+
+func (c *combined) Close() error {
+	if err := c.tcp.Close(); err != nil {
+		return err
+	}
+	if err := c.tls.Close(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/socket/combined_test.go
+++ b/internal/socket/combined_test.go
@@ -1,0 +1,108 @@
+package socket
+
+import (
+	ctls "crypto/tls"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCombinedSocketListenAndServe(t *testing.T) {
+	conf := newTestTLSConfig()
+	c := NewCombinedSocket(0, 0, conf).(*combined)
+
+	if err := c.Bind(); err != nil {
+		t.Fatalf("Bind failed: %v", err)
+	}
+	defer c.Close()
+
+	tcpCalled := make(chan struct{})
+	tlsCalled := make(chan struct{})
+
+	go c.Serve(
+		func(conn net.Conn) {
+			defer conn.Close()
+			if _, ok := conn.(*ctls.Conn); ok {
+				close(tlsCalled)
+			} else {
+				close(tcpCalled)
+			}
+			if _, err := conn.Write([]byte("OK")); err != nil {
+				t.Errorf("failed to write to connection: %+v", err)
+			}
+		},
+		func(err error) {
+			if strings.Contains(err.Error(), "use of closed network connection") {
+				return
+			}
+			t.Errorf("unexpected error: %v", err)
+		},
+	)
+
+	tcpAddr := c.tcp.(*tcp).ln.Addr().String()
+	tcpConn, err := net.Dial("tcp", tcpAddr)
+	if err != nil {
+		t.Fatalf("failed to dial TCP server: %v", err)
+	}
+	tcpConn.Close()
+
+	tlsAddr := c.tls.(*tls).ln.Addr().String()
+	clientConf := conf.Clone()
+	clientConf.InsecureSkipVerify = true
+	tlsConn, err := ctls.Dial("tcp", tlsAddr, clientConf)
+	if err != nil {
+		t.Fatalf("failed to dial TLS server: %v", err)
+	}
+	tlsConn.Close()
+
+	select {
+	case <-tcpCalled:
+	case <-time.After(time.Second):
+		t.Fatal("TCP consumer was not called in time")
+	}
+
+	select {
+	case <-tlsCalled:
+	case <-time.After(time.Second):
+		t.Fatal("TLS consumer was not called in time")
+	}
+}
+
+func TestCombinedSocketClose(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func(Socket)
+		wantErr bool
+	}{
+		{
+			name: "success",
+			setup: func(s Socket) {
+				if err := s.Bind(); err != nil {
+					t.Fatalf("unexpected error while binding: %+v", err)
+				}
+			},
+		},
+		{
+			name:    "socket not bound",
+			setup:   func(s Socket) {},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := NewCombinedSocket(0, 0, newTestTLSConfig())
+			tc.setup(s)
+
+			err := s.Close()
+
+			if err != nil && !tc.wantErr {
+				t.Errorf("unexpected error: %+v", err)
+			}
+			if err == nil && tc.wantErr {
+				t.Error("wanted error but not found")
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Summary
<!-- A high level summary of the changes, including any gotchas that the reviewer should watch out for when reviewing. -->

This PR combines the two `Socket` implementations for plain TCP and TLS over TCP into a combined socket. This allows a server to listen (on different ports) to both HTTP and HTTPS communications, which many servers commonly do. Individual TCP and TLS over TCP sockets are bound and spun up when the combined socket begins listening. Since `Socket.Serve` is typically blocking, the two invocations are put in separate go-routines. To maintain consistency, we use channels to block the new implementation of `Socket.Serve`, which will continue to block until both sockets close (and therefore terminate their own implementations of `Socket.Serve`). We can rely on the two underlying sockets being thread-safe, so don't have any explicit thread-safe behaviour or mechanisms in this implementation.

### Motivation
<!-- Why is this change necessary? This can be a link to a GitHub issue or reproduction steps for a bug etc. -->

A user may want to accept both HTTP and HTTPS messages. In that case, we need two separate ports and listeners. By implementing the `Socket` interface, we would not need to change any of the server's code (apart from initialisation) to support listening on both ports.

### Test plan
<!-- How did you test the changes? Are there edge cases you are missing or were unable to test? -->

- [x] Unit tests
