### PR TITLE
[https] Allow test client to be TLS aware

### DIFF
--- a/examples/https/both/main_test.go
+++ b/examples/https/both/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/tls"
 	"strconv"
 	"testing"
 
@@ -18,6 +19,11 @@ func TestServer(t *testing.T) {
 			name:     "http",
 			client:   routeit.NewTestClient(srv),
 			wantBody: "Hello world!",
+		},
+		{
+			name:     "https",
+			client:   routeit.NewTestTlsClient(srv, &tls.ConnectionState{}),
+			wantBody: "Hello world! Thanks for being secure!",
 		},
 	}
 

--- a/test_request.go
+++ b/test_request.go
@@ -1,6 +1,7 @@
 package routeit
 
 import (
+	"crypto/tls"
 	"fmt"
 	"strings"
 	"testing"
@@ -28,6 +29,10 @@ type TestRequestOptions struct {
 	// through the entire handling flow, meaning requests are not routed
 	// properly so path parameters are not extracted.
 	PathParams map[string]string
+	// The TLS connection state. Use this if the middleware or handler under
+	// test is TLS aware (e.g. middleware that may block clients if they are
+	// not using TLS)
+	TlsConnectionState *tls.ConnectionState
 }
 
 // The [TestRequest] object can be used when unit testing specific components
@@ -63,13 +68,14 @@ func NewTestRequest(t testing.TB, path string, m HttpMethod, opts TestRequestOpt
 
 	headers := &RequestHeaders{constructTestHeaders(opts.Headers...)}
 	req := &Request{
-		ctx:     t.Context(),
-		mthd:    m,
-		uri:     *uri,
-		headers: headers,
-		body:    opts.Body,
-		ip:      opts.Ip,
-		accept:  parseAcceptHeader(headers),
+		ctx:      t.Context(),
+		mthd:     m,
+		uri:      *uri,
+		headers:  headers,
+		body:     opts.Body,
+		ip:       opts.Ip,
+		accept:   parseAcceptHeader(headers),
+		tlsState: opts.TlsConnectionState,
 	}
 
 	if host, hasHost := headers.First("Host"); hasHost {


### PR DESCRIPTION
### Summary
<!-- A high level summary of the changes, including any gotchas that the reviewer should watch out for when reviewing. -->

This PR updates the creation of the `TestClient` to allow users to create a TLS-aware test client. The TLS connection state provided is passed into the server to handle a request in E2E tests. We do the same in unit tests for handlers and middleware, where the `TestRequestOptions` struct is extended to also include TLS connection state.

### Motivation
<!-- Why is this change necessary? This can be a link to a GitHub issue or reproduction steps for a bug etc. -->

Some handlers and middleware are TLS-aware - i.e. they may reject a request if it is not using TLS or decide to only expose certain information etc. Previously there was no way to test this automatically, as there was no mechanism to inject TLS state into either unit or E2E tests.

### Test plan
<!-- How did you test the changes? Are there edge cases you are missing or were unable to test? -->

- [x] Existing
