### PR TITLE
[https] HTTPS only example server

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -12,6 +12,7 @@ jobs:
                 - errors/handling
                 - errors/mapping
                 - https/both
+                - https/https-only
                 - middleware/complex
                 - middleware/cors
                 - middleware/simple

--- a/examples/https/README.md
+++ b/examples/https/README.md
@@ -4,6 +4,7 @@
 This examples directory contains a number of examples for the different combinations of HTTP + HTTPS options a user of `routeit` has.
 
 - [`both`](/examples/https/both/) - this server responds to both HTTP and HTTPS connections, and infers which type of connection was used.
+- [`https-only`](/examples/https/https-only/) - this server only responds to HTTPS connections.
 
 ### Certificates
 

--- a/examples/https/https-only/README.md
+++ b/examples/https/https-only/README.md
@@ -1,0 +1,40 @@
+### examples/https/https-only
+
+This example project only accepts HTTPS requests.
+Requests over HTTP will not succeed, due there not being a port that listens for plain TCP requests.
+The app can be run using `go run main.go`.
+
+There is 1 endpoint exposed, which tells the client what TLS Version and Cipher Suites it negotiated in the TLS handshake, as well as the name of the Server.
+
+```bash
+# HTTPS request
+$ curl --cacert ../certs/ca.crt https://localhost:8443/info
+{"version":"TLS 1.3","cipher_suite":"TLS_CHACHA20_POLY1305_SHA256","server_name":"localhost"}
+
+# HTTP request
+$ curl http://localhost:8443/info -v -i
+* Host localhost:8443 was resolved.
+* IPv6: ::1
+* IPv4: 127.0.0.1
+*   Trying [::1]:8443...
+* Connected to localhost (::1) port 8443
+> GET /info HTTP/1.1
+> Host: localhost:8443
+> User-Agent: curl/8.7.1
+> Accept: */*
+>
+* Request completely sent off
+* Empty reply from server
+* Closing connection
+curl: (52) Empty reply from server
+
+# When targeting an IP directly, the server's name is not included in the TLS handshake
+
+# HTTPS request to IPv4 host name
+$ curl --cacert ../certs/ca.crt "https://127.0.0.1:8443/info"
+{"version":"TLS 1.3","cipher_suite":"TLS_CHACHA20_POLY1305_SHA256","server_name":""}
+
+# HTTPS request to IPv6 host name
+$ curl --cacert ../certs/ca.crt "https://[::1]:8443/info"
+{"version":"TLS 1.3","cipher_suite":"TLS_CHACHA20_POLY1305_SHA256","server_name":""}
+```

--- a/examples/https/https-only/go.mod
+++ b/examples/https/https-only/go.mod
@@ -1,0 +1,7 @@
+module github.com/sktylr/routeit/examples/https/https-only
+
+go 1.24.4
+
+replace github.com/sktylr/routeit => ../../..
+
+require github.com/sktylr/routeit v1.1.0

--- a/examples/https/https-only/main.go
+++ b/examples/https/https-only/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"crypto/tls"
+
+	"github.com/sktylr/routeit"
+)
+
+type InfoResponse struct {
+	Version     string `json:"version"`
+	CipherSuite string `json:"cipher_suite"`
+	ServerName  string `json:"server_name"`
+}
+
+func GetServer() *routeit.Server {
+	srv := routeit.NewServer(routeit.ServerConfig{
+		Debug: true,
+		HttpConfig: routeit.HttpConfig{
+			HttpsPort: 8443,
+			TlsConfig: routeit.NewTlsConfigForCertAndKey("../certs/localhost.crt", "../certs/localhost.key"),
+		},
+	})
+	srv.RegisterRoutes(routeit.RouteRegistry{
+		"/info": routeit.Get(func(rw *routeit.ResponseWriter, req *routeit.Request) error {
+			// Since the server will only accept TLS-backed HTTPS request over
+			// port 8443, we can safely assume that [routeit.Request.Tls] is
+			// non-nil.
+			res := InfoResponse{
+				Version:     tls.VersionName(req.Tls().Version),
+				CipherSuite: tls.CipherSuiteName(req.Tls().CipherSuite),
+				ServerName:  req.Tls().ServerName,
+			}
+			return rw.Json(res)
+		}),
+	})
+	return srv
+}
+
+func main() { GetServer().StartOrPanic() }

--- a/examples/https/https-only/main_test.go
+++ b/examples/https/https-only/main_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"crypto/tls"
+	"reflect"
+	"testing"
+
+	"github.com/sktylr/routeit"
+)
+
+func TestServer(t *testing.T) {
+	tests := []struct {
+		name     string
+		tlsState *tls.ConnectionState
+		wantRes  InfoResponse
+	}{
+		{
+			name: "valid",
+			tlsState: &tls.ConnectionState{
+				Version:     tls.VersionTLS13,
+				ServerName:  "foo-bar-server",
+				CipherSuite: tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+			},
+			wantRes: InfoResponse{
+				Version:     "TLS 1.3",
+				ServerName:  "foo-bar-server",
+				CipherSuite: "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
+			},
+		},
+		{
+			name: "fallback",
+			tlsState: &tls.ConnectionState{
+				Version:     1234,
+				ServerName:  "foo-bar-server",
+				CipherSuite: 5678,
+			},
+			wantRes: InfoResponse{
+				Version:     "0x04D2",
+				ServerName:  "foo-bar-server",
+				CipherSuite: "0x162E",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := routeit.NewTestTlsClient(GetServer(), tc.tlsState)
+
+			res := client.Get("/info")
+
+			res.AssertStatusCode(t, routeit.StatusOK)
+			var body InfoResponse
+			res.BodyToJson(t, &body)
+			if !reflect.DeepEqual(body, tc.wantRes) {
+				t.Errorf(`mismatching body, got = %+v, want = %+v`, body, tc.wantRes)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Summary
<!-- A high level summary of the changes, including any gotchas that the reviewer should watch out for when reviewing. -->

This PR introduces a new example server that only accepts HTTPS requests. Plain HTTP requests will not reach the server logic and will be closed due to the server expecting a TLS handshake after the TCP handshake.

The server exposes 1 endpoint that shows some details about the client and server's TLS handshake.

### Motivation
<!-- Why is this change necessary? This can be a link to a GitHub issue or reproduction steps for a bug etc. -->

To show how to make a server only accept HTTPS communication, as well as verifying that the TLS connection state stored on the request is correct.

### Test plan
<!-- How did you test the changes? Are there edge cases you are missing or were unable to test? -->

- [x] New E2E test
- [x] Local testing using cURL
