### PR TITLE
[https] Middleware to upgrade HTTP to HTTPS

### DIFF
--- a/config.go
+++ b/config.go
@@ -121,13 +121,17 @@ type ServerConfig struct {
 }
 
 // The [HttpConfig] is used to specify details of the port(s) that the server
-// will listen on. If it is left empty, the server will respond to HTTP
-// requests on port 80. If a [tls.Config] is provided, the server will respond
-// to HTTPS requests, defaulting to listening on port 443. If it is desirable
-// to listen to both HTTP and HTTPS requests, the HTTP port will need to be
-// explicitly configured, commonly to port 80. In such cases, the HTTPS port
-// only needs to be set if listening to HTTPS requests on port 443 is not
-// desired.
+// will listen on. If left empty, the server will respond to HTTP requests on
+// port 8080. If a [tls.Config] is provided, the server will respond to HTTPS
+// requests, defaulting to listening on port 443. If it is desirable to listen
+// to both HTTP and HTTPS requests, the HTTP port will need to be explicitly
+// configured, commonly to port 80. In such cases, the HTTPS port only needs to
+// be set if listening to HTTPS requests on port 443 is not desired. When HTTPS
+// is enabled, the server can also instruct client to upgrade any HTTP
+// communication to HTTPS, controlled using [HttpConfig.UpgradeToHttps] and
+// [HttpConfig.UpgradeInstructionMaxAge]. If a HTTP port is not selected, but
+// UpgradeToHttps is enabled, the server will listen for HTTP messages on port
+// 80.
 type HttpConfig struct {
 	// This is the port that the HTTP listener will listen on. If the entire
 	// [HttpConfig] is left empty, this will default to port 8080. If a
@@ -146,6 +150,17 @@ type HttpConfig struct {
 	// will not expect HTTP messages. Configure the [HttpConfig.HttpPort]
 	// explicitly if it is desirable to listen to both HTTP and HTTPS requests.
 	TlsConfig *tls.Config
+	// Set this flag if you want the server to instruct clients to upgrade
+	// their HTTP messages to HTTPS. Enabling this flag with a valid TLS config
+	// and no HTTP port selected will default to the server listening for plain
+	// HTTP messages on port 80, and HTTPS messages on the chosen port (or
+	// defaulted to 443).
+	UpgradeToHttps bool
+	// Determines how long clients are instructed to remember to use HTTPS for
+	// the server and its host subdomains. Set to 0 if the client should not
+	// choose to remember. Only relevant when [HttpConfig.UpgradeToHttps] is
+	// set, otherwise its value is ignored.
+	UpgradeInstructionMaxAge time.Duration
 }
 
 // The internal server config, which only stores the necessary values
@@ -192,17 +207,29 @@ func (sc ServerConfig) internalise() serverConfig {
 			AllowTraceRequests:     sc.AllowTraceRequests,
 		},
 	}
-	if sc.TlsConfig == nil && sc.HttpsPort != 0 {
-		panic("cannot choose a https port without a tls config")
+	if sc.TlsConfig == nil {
+		if sc.HttpsPort != 0 {
+			panic("cannot choose a https port without a tls config")
+		}
+		if sc.UpgradeToHttps {
+			panic("cannot upgrade to https without a tls config")
+		}
 	}
+
 	if sc.RequestSize == 0 {
 		out.RequestSize = KiB
 	}
 	if sc.TlsConfig != nil {
-		// We are using TLS so require a HTTPS port. If not supplied, we
-		// default to 443
 		if sc.HttpsPort == 0 {
+			// We are using TLS so require a HTTPS port. If not supplied, we
+			// default to 443
 			out.HttpsPort = 443
+		}
+		if sc.UpgradeToHttps && sc.HttpPort == 0 {
+			// Since we are explicitly upgrading HTTP to HTTPS, we need to
+			// listen for HTTP requests. We don't have a port to listen on, so
+			// default to 80
+			out.HttpPort = 80
 		}
 	} else if sc.HttpPort == 0 && sc.HttpsPort == 0 {
 		// No ports have been provided and we are not using TLS, so default to

--- a/https_middleware.go
+++ b/https_middleware.go
@@ -1,0 +1,39 @@
+package routeit
+
+import (
+	"fmt"
+	"time"
+)
+
+// This middleware will prevent the server from acting upon HTTP requests and
+// instruct the client to use HTTPS connections instead. When a plain HTTP
+// request is received, we redirect the client to the equivalent resource using
+// the HTTPS scheme. Many clients (e.g. browsers) will automatically handle
+// this redirection. Once a HTTPS request is received, we want to tell the
+// client to remember to use HTTPS for all future requests to this host, which
+// is done using the Strict-Transport-Security header (RFC-6797). This header
+// tells the client how long to cache the HTTPS upgrade instruction for, and
+// also to respect this instruction on all subdomains of the host.
+func upgradeToHttpsMiddleware(httpsPort uint16, maxAge time.Duration) Middleware {
+	return func(c Chain, rw *ResponseWriter, req *Request) error {
+		if req.tlsState != nil {
+			// Inform the client that HTTPS is the preferred option using the
+			// HTTP Strict Transport Security (HSTS) headers. Browsers will
+			// cache this for as long as specified in max-age and will
+			// automatically use HTTPS for subsequent requests.
+			hsts := fmt.Sprintf("max-age=%d; includeSubdomains", int(maxAge.Seconds()))
+			rw.Headers().Set("Strict-Transport-Security", hsts)
+			return c.Proceed(rw, req)
+		}
+
+		host := req.host
+		endpoint := req.RawPath()
+		location := fmt.Sprintf("https://%s:%d%s", host, httpsPort, endpoint)
+
+		// The request is over HTTP so we inform the client to redirect to the
+		// equivalent HTTPS resource.
+		rw.Headers().Set("Location", location)
+		rw.Status(StatusMovedPermanently)
+		return nil
+	}
+}

--- a/https_middleware_test.go
+++ b/https_middleware_test.go
@@ -1,0 +1,53 @@
+package routeit
+
+import (
+	"crypto/tls"
+	"testing"
+	"time"
+)
+
+func TestUpgradeToHttpsMiddleware(t *testing.T) {
+	tests := []struct {
+		name        string
+		opts        TestRequestOptions
+		validateRes func(t *testing.T, res *TestResponse)
+		wantProceed bool
+	}{
+		{
+			name: "https uses HSTS",
+			opts: TestRequestOptions{TlsConnectionState: &tls.ConnectionState{}},
+			validateRes: func(t *testing.T, res *TestResponse) {
+				val := "max-age=31536000; includeSubdomains"
+				res.AssertHeaderMatchesString(t, "Strict-Transport-Security", val)
+			},
+			wantProceed: true,
+		},
+		{
+			name: "http redirected",
+			opts: TestRequestOptions{
+				Headers: []string{"Host", "example.com"},
+			},
+			validateRes: func(t *testing.T, res *TestResponse) {
+				res.AssertStatusCode(t, StatusMovedPermanently)
+				res.AssertHeaderMatchesString(t, "Location", "https://example.com:443/foo")
+			},
+		},
+	}
+	mware := upgradeToHttpsMiddleware(443, 365*24*time.Hour)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := NewTestRequest(t, "/foo", GET, tc.opts)
+
+			res, proceeded, err := TestMiddleware(mware, req)
+
+			if err != nil {
+				t.Errorf(`err = %+v, wanted nil`, err)
+			}
+			if proceeded != tc.wantProceed {
+				t.Errorf(`proceeded = %t, wanted %t`, proceeded, tc.wantProceed)
+			}
+			tc.validateRes(t, res)
+		})
+	}
+}

--- a/server.go
+++ b/server.go
@@ -65,26 +65,7 @@ func NewServer(conf ServerConfig) *Server {
 	if conf.AllowTraceRequests {
 		s.RegisterMiddleware(allowTraceValidationMiddleware())
 	}
-	if conf.TlsConfig != nil {
-		tlsConf := conf.TlsConfig.Clone()
-		// We only support HTTP/1.1 so we override any settings the user has
-		// provided to ensure we can respond to the client properly.
-		tlsConf.NextProtos = []string{"http/1.1"}
-		if conf.HttpPort != 0 && conf.HttpsPort != 0 {
-			s.sock = socket.NewCombinedSocket(conf.HttpPort, conf.HttpsPort, tlsConf)
-			if conf.UpgradeToHttps {
-				s.RegisterMiddleware(
-					upgradeToHttpsMiddleware(conf.HttpsPort, conf.UpgradeInstructionMaxAge),
-				)
-			}
-		} else {
-			// By construction, we know the HTTPS port is non-zero and the HTTP
-			// port is 0, so we only want to listen for HTTPS messages.
-			s.sock = socket.NewTlsSocket(conf.HttpsPort, tlsConf)
-		}
-	} else {
-		s.sock = socket.NewTcpSocket(conf.HttpPort)
-	}
+	s.configureSocket(conf)
 	return s
 }
 
@@ -275,6 +256,33 @@ func (s *Server) handleNewRequest(raw []byte, addr net.Addr, tls *tls.Connection
 	// multiple streams that the error can come from, since we also want to
 	// avoid letting panics halt the whole server.
 	return rw
+}
+
+// Configures the socket that the server will use to listen for and respond to
+// requests.
+func (s *Server) configureSocket(conf ServerConfig) {
+	if conf.TlsConfig == nil {
+		s.sock = socket.NewTcpSocket(conf.HttpPort)
+		return
+	}
+
+	// We only support HTTP/1.1 so we override any settings the user has
+	// provided to ensure we can respond to the client properly.
+	tlsConf := conf.TlsConfig.Clone()
+	tlsConf.NextProtos = []string{"http/1.1"}
+
+	if conf.HttpPort == 0 {
+		// By construction, we know the HTTPS port is non-zero and the HTTP
+		// port is 0, so we only want to listen for HTTPS messages.
+		s.sock = socket.NewTlsSocket(conf.HttpsPort, tlsConf)
+	}
+
+	s.sock = socket.NewCombinedSocket(conf.HttpPort, conf.HttpsPort, tlsConf)
+	if conf.UpgradeToHttps {
+		s.RegisterMiddleware(
+			upgradeToHttpsMiddleware(conf.HttpsPort, conf.UpgradeInstructionMaxAge),
+		)
+	}
 }
 
 // This is the outermost piece of middleware and ensures that the request does

--- a/server.go
+++ b/server.go
@@ -72,6 +72,11 @@ func NewServer(conf ServerConfig) *Server {
 		tlsConf.NextProtos = []string{"http/1.1"}
 		if conf.HttpPort != 0 && conf.HttpsPort != 0 {
 			s.sock = socket.NewCombinedSocket(conf.HttpPort, conf.HttpsPort, tlsConf)
+			if conf.UpgradeToHttps {
+				s.RegisterMiddleware(
+					upgradeToHttpsMiddleware(conf.HttpsPort, conf.UpgradeInstructionMaxAge),
+				)
+			}
 		} else {
 			// By construction, we know the HTTPS port is non-zero and the HTTP
 			// port is 0, so we only want to listen for HTTPS messages.

--- a/server_test.go
+++ b/server_test.go
@@ -69,7 +69,21 @@ func TestNewServer(t *testing.T) {
 					},
 				},
 				want: func(s serverConfig) serverConfig {
-					s.HttpPort = 8080
+					s.HttpsPort = 443
+					return s
+				},
+			},
+			{
+				name: "TLS config and upgrade http to https, no http port",
+				in: ServerConfig{
+					HttpConfig: HttpConfig{
+						TlsConfig:                &tls.Config{},
+						UpgradeToHttps:           true,
+						UpgradeInstructionMaxAge: time.Hour,
+					},
+				},
+				want: func(s serverConfig) serverConfig {
+					s.HttpPort = 80
 					s.HttpsPort = 443
 					return s
 				},
@@ -161,6 +175,10 @@ func TestNewServer(t *testing.T) {
 			{
 				name: "https port provided but no TLS config",
 				conf: ServerConfig{HttpConfig: HttpConfig{HttpsPort: 443}},
+			},
+			{
+				name: "upgrade to HTTPS but not TLS config",
+				conf: ServerConfig{HttpConfig: HttpConfig{UpgradeToHttps: true}},
 			},
 		}
 


### PR DESCRIPTION
### Summary
<!-- A high level summary of the changes, including any gotchas that the reviewer should watch out for when reviewing. -->

This PR adds config options and middleware to upgrade HTTP connections to HTTPS.

When the server receives a HTTP connection, it can redirect to the corresponding HTTPS URI. Most clients will follow this redirect, or at least surface it to the user. From there, they will establish the TLS handshake and make a HTTPS request. When the server receives a HTTPS request, they can also inform the client to keep using that scheme for future requests. Using a `max-age` value in a header, the server can inform the client to cache the instruction to use HTTPS for a specific amount of time. Some clients don't respect this, but all browsers do.

The enablement of this config option is done by introducing two new fields - `UpgradeToHttps` and `UpgradeInstructionMaxAge` to `ServerConfig.HttpConfig`. These are validated properly (such as ensuring they are not enabled when the server is not enabled for HTTPS), and also mean that we know the server will be responding to both HTTP and HTTPS communication. So, unlike in previous scenarios, if the user doesn't provide a HTTP port to listen on, we listen on the default HTTP port of 80 if these config options are enabled.

### Motivation
<!-- Why is this change necessary? This can be a link to a GitHub issue or reproduction steps for a bug etc. -->

Some servers wish to receive both HTTP and HTTPS traffic, but only want to process HTTPS traffic. They want traffic over HTTP to be instructed to retry using HTTPS for security purposes. `routeit` already allows creating a server that listens for both HTTP and HTTPS traffic, so it seems sensible that this behaviour could also be controllable. 

### Test plan
<!-- How did you test the changes? Are there edge cases you are missing or were unable to test? -->

- [x] Unit tests (new + old)
- [x] Local tests
