### PR TITLE
[https] Example for upgrading HTTP to HTTPS

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -13,6 +13,7 @@ jobs:
                 - errors/mapping
                 - https/both
                 - https/https-only
+                - https/upgrade-http
                 - middleware/complex
                 - middleware/cors
                 - middleware/simple

--- a/examples/https/README.md
+++ b/examples/https/README.md
@@ -5,6 +5,7 @@ This examples directory contains a number of examples for the different combinat
 
 - [`both`](/examples/https/both/) - this server responds to both HTTP and HTTPS connections, and infers which type of connection was used.
 - [`https-only`](/examples/https/https-only/) - this server only responds to HTTPS connections.
+- [`upgrade-http`](/examples/https/upgrade-http/) - this server accepts both HTTP and HTTPS connections, but instructs HTTP clients to upgrade to HTTPS before it will process the requests.
 
 ### Certificates
 

--- a/examples/https/upgrade-http/README.md
+++ b/examples/https/upgrade-http/README.md
@@ -1,0 +1,47 @@
+### examples/https/upgrade-http
+
+This example server showcases what happens when a server is willing to accept both HTTP and HTTPS connections, but instructs the client to upgrade their connection to HTTPS before it will be processed.
+This functionality is built into `routeit` is is managed through `ServerConfig.HttpConfig.UpgradeToHttps` and `ServerConfig.HttpConfig.UpgradeInstructionMaxAge`.
+The server must already be willing to listen for HTTPS connections (and therefore have a TLS config) for these settings to take effect.
+The server can be run using `go run main.go`.
+
+Only 1 endpoint is exposed, which is `/echo`.
+This responds to `GET` requests and will echo the `message` query parameter, or respond with `"You didn't send a message!"` if the parameter is not present.
+It also takes the first occurrence of `message` in the query parameters when parsing the request.
+
+```bash
+# HTTPS request with a message
+# The Strict-Transport-Security response header is included here by the server
+# to tell the client that it should continue to use HTTPS, and should remember
+# that decision for at least 1 second, including on any subdomains of the host
+$ curl --cacert ../certs/ca.crt --get https://localhost:8443/echo --data-urlencode "message=Hello over HTTPS" -i
+HTTP/1.1 200 OK
+Strict-Transport-Security: max-age=1; includeSubdomains
+Content-Length: 16
+Content-Type: text/plain
+Date: Tue, 09 Sep 2025 21:53:45 GMT
+Server: routeit
+
+Hello over HTTPS
+
+# HTTPS request without a message
+# The Strict-Transport-Security header is also included here
+$ curl --cacert ../certs/ca.crt https://localhost:8443/echo -i
+HTTP/1.1 200 OK
+Server: routeit
+Strict-Transport-Security: max-age=1; includeSubdomains
+Content-Length: 26
+Content-Type: text/plain
+Date: Tue, 09 Sep 2025 21:54:09 GMT
+
+You didn't send a message!
+
+# Plain HTTP request
+# This is redirected to the correct HTTPS URI
+$ curl http://localhost:8123/echo  -i
+HTTP/1.1 301 Moved Permanently
+Server: routeit
+Location: https://localhost:8443/echo
+Date: Tue, 09 Sep 2025 21:55:53 GMT
+
+```

--- a/examples/https/upgrade-http/go.mod
+++ b/examples/https/upgrade-http/go.mod
@@ -1,0 +1,7 @@
+module github.com/sktylr/routeit/examples/https/upgrade-http
+
+go 1.24.4
+
+replace github.com/sktylr/routeit => ../../..
+
+require github.com/sktylr/routeit v1.1.0

--- a/examples/https/upgrade-http/main.go
+++ b/examples/https/upgrade-http/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"time"
+
+	"github.com/sktylr/routeit"
+)
+
+func GetServer() *routeit.Server {
+	srv := routeit.NewServer(routeit.ServerConfig{
+		AllowedHosts: []string{".localhost", "example.com", "127.0.0.1", "[::1]"},
+		HttpConfig: routeit.HttpConfig{
+			HttpPort:                 8123,
+			HttpsPort:                8443,
+			TlsConfig:                routeit.NewTlsConfigForCertAndKey("../certs/localhost.crt", "../certs/localhost.key"),
+			UpgradeToHttps:           true,
+			UpgradeInstructionMaxAge: time.Second,
+		},
+	})
+	srv.RegisterRoutes(routeit.RouteRegistry{
+		"/echo": routeit.Get(func(rw *routeit.ResponseWriter, req *routeit.Request) error {
+			msg, hasMsg := req.Queries().First("message")
+			if !hasMsg {
+				msg = "You didn't send a message!"
+			}
+			rw.Text(msg)
+			return nil
+		}),
+	})
+	return srv
+}
+
+func main() { GetServer().StartOrPanic() }

--- a/examples/https/upgrade-http/main_test.go
+++ b/examples/https/upgrade-http/main_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"github.com/sktylr/routeit"
+)
+
+func TestServer(t *testing.T) {
+	srv := GetServer()
+
+	t.Run("http redirected", func(t *testing.T) {
+		client := routeit.NewTestClient(srv)
+
+		res := client.Get("/echo", "Host", "example.com")
+
+		res.AssertStatusCode(t, routeit.StatusMovedPermanently)
+		res.AssertHeaderMatchesString(t, "Location", "https://example.com:8443/echo")
+	})
+
+	t.Run("https uses HSTS", func(t *testing.T) {
+		client := routeit.NewTestTlsClient(srv, &tls.ConnectionState{})
+
+		res := client.Get("/echo?message=Hello")
+
+		res.AssertStatusCode(t, routeit.StatusOK)
+		res.AssertBodyMatchesString(t, "Hello")
+		res.AssertHeaderMatchesString(t, "Strict-Transport-Security", "max-age=1; includeSubdomains")
+	})
+}


### PR DESCRIPTION
### Summary
<!-- A high level summary of the changes, including any gotchas that the reviewer should watch out for when reviewing. -->

This PR adds a simple example app that showcases how `routeit` automatically handles upgrading connections from HTTP to HTTPS if enabled on the server.

### Motivation
<!-- Why is this change necessary? This can be a link to a GitHub issue or reproduction steps for a bug etc. -->

Validation of the concept and a demonstration of it.

### Test plan
<!-- How did you test the changes? Are there edge cases you are missing or were unable to test? -->

- [x] E2E tests
- [x] Local testing
