### PR TITLE
Patch default port settings

### DIFF
--- a/config.go
+++ b/config.go
@@ -180,6 +180,12 @@ type handlingConfig struct {
 	StrictClientAcceptance bool
 }
 
+type httpsConfig struct {
+	TlsConfig                *tls.Config
+	UpgradeToHttps           bool
+	UpgradeInstructionMaxAge time.Duration
+}
+
 // This is a convenience method for instantiating a TLS config with a single
 // certificate and key. This will panic if the certificate or key cannot be
 // loaded. [crypto/tls] sets sensible defaults for TLS config, so this is safe

--- a/server.go
+++ b/server.go
@@ -65,7 +65,11 @@ func NewServer(conf ServerConfig) *Server {
 	if conf.AllowTraceRequests {
 		s.RegisterMiddleware(allowTraceValidationMiddleware())
 	}
-	s.configureSocket(conf)
+	s.configureSocket(httpsConfig{
+		TlsConfig:                conf.TlsConfig,
+		UpgradeToHttps:           conf.UpgradeToHttps,
+		UpgradeInstructionMaxAge: conf.UpgradeInstructionMaxAge,
+	})
 	return s
 }
 
@@ -260,7 +264,7 @@ func (s *Server) handleNewRequest(raw []byte, addr net.Addr, tls *tls.Connection
 
 // Configures the socket that the server will use to listen for and respond to
 // requests.
-func (s *Server) configureSocket(conf ServerConfig) {
+func (s *Server) configureSocket(conf httpsConfig) {
 	if conf.TlsConfig == nil {
 		s.sock = socket.NewTcpSocket(s.conf.HttpPort)
 		return


### PR DESCRIPTION
### Summary
<!-- A high level summary of the changes, including any gotchas that the reviewer should watch out for when reviewing. -->

This PR introduces a private struct `httpsConfig` which hold the TLS config and HTTP -> HTTPS upgrade settings. This struct is passed in to the server's `configureSocket` method, which is used for the non-persistent settings (i.e. those not saved to the server's internal config for future use).

The HTTP(S) port(s) are still stored on the server, as they have other uses (e.g. in logging when the server is started). However, there is no need for the TLS and HTTPS upgrade information since that is stored within the socket and middleware respectively.

Doing this means that when configuring the sockets, there is only 1 source of truth for the socket options, meaning we can't end up in a situation where we have two conflicting values for the same construct.

### Motivation
<!-- Why is this change necessary? This can be a link to a GitHub issue or reproduction steps for a bug etc. -->

After `v1.2.0`, there was an issue with port defaulting in HTTP only servers. `serverConfig.internalise` would correctly assign the default port of 8080 to the server, but this value would not be used when creating a socket. Instead, the empty value (0) was used from the non-mutated `ServerConfig` object. This resulted in the `net` library using an ephemeral port, meaning one was randomly assigned by the OS. As a result, clients could not predict the port the server would be listening on and would be unable to connect.

### Test plan
<!-- How did you test the changes? Are there edge cases you are missing or were unable to test? -->

- [x] Existing tests
- [x] Local tests with http only example
