### PR TITLE
[chore] Bump examples to `v1.2.1`

### DIFF
--- a/examples/errors/handling/go.mod
+++ b/examples/errors/handling/go.mod
@@ -2,4 +2,4 @@ module github.com/sktylr/routeit/examples/errors/handling
 
 go 1.24.4
 
-require github.com/sktylr/routeit v1.2.0
+require github.com/sktylr/routeit v1.2.1

--- a/examples/errors/handling/go.sum
+++ b/examples/errors/handling/go.sum
@@ -1,2 +1,2 @@
-github.com/sktylr/routeit v1.2.0 h1:lBhIJFyQNo9JI45bbXXARdhWz+CI14cZPs3v7aBNmbQ=
-github.com/sktylr/routeit v1.2.0/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=
+github.com/sktylr/routeit v1.2.1 h1:mmKsH77Q2gTAXzZKPU/1oAuKQnPGY+/cs5vpnk2BYJ0=
+github.com/sktylr/routeit v1.2.1/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/errors/mapping/go.mod
+++ b/examples/errors/mapping/go.mod
@@ -2,4 +2,4 @@ module github.com/sktylr/routeit/examples/errors/mapping
 
 go 1.24.4
 
-require github.com/sktylr/routeit v1.2.0
+require github.com/sktylr/routeit v1.2.1

--- a/examples/errors/mapping/go.sum
+++ b/examples/errors/mapping/go.sum
@@ -1,2 +1,2 @@
-github.com/sktylr/routeit v1.2.0 h1:lBhIJFyQNo9JI45bbXXARdhWz+CI14cZPs3v7aBNmbQ=
-github.com/sktylr/routeit v1.2.0/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=
+github.com/sktylr/routeit v1.2.1 h1:mmKsH77Q2gTAXzZKPU/1oAuKQnPGY+/cs5vpnk2BYJ0=
+github.com/sktylr/routeit v1.2.1/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/https/both/go.mod
+++ b/examples/https/both/go.mod
@@ -2,4 +2,4 @@ module github.com/sktylr/routeit/examples/https/both
 
 go 1.24.4
 
-require github.com/sktylr/routeit v1.2.0
+require github.com/sktylr/routeit v1.2.1

--- a/examples/https/both/go.sum
+++ b/examples/https/both/go.sum
@@ -1,2 +1,2 @@
-github.com/sktylr/routeit v1.2.0 h1:lBhIJFyQNo9JI45bbXXARdhWz+CI14cZPs3v7aBNmbQ=
-github.com/sktylr/routeit v1.2.0/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=
+github.com/sktylr/routeit v1.2.1 h1:mmKsH77Q2gTAXzZKPU/1oAuKQnPGY+/cs5vpnk2BYJ0=
+github.com/sktylr/routeit v1.2.1/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/https/https-only/go.mod
+++ b/examples/https/https-only/go.mod
@@ -2,4 +2,4 @@ module github.com/sktylr/routeit/examples/https/https-only
 
 go 1.24.4
 
-require github.com/sktylr/routeit v1.2.0
+require github.com/sktylr/routeit v1.2.1

--- a/examples/https/https-only/go.sum
+++ b/examples/https/https-only/go.sum
@@ -1,2 +1,2 @@
-github.com/sktylr/routeit v1.2.0 h1:lBhIJFyQNo9JI45bbXXARdhWz+CI14cZPs3v7aBNmbQ=
-github.com/sktylr/routeit v1.2.0/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=
+github.com/sktylr/routeit v1.2.1 h1:mmKsH77Q2gTAXzZKPU/1oAuKQnPGY+/cs5vpnk2BYJ0=
+github.com/sktylr/routeit v1.2.1/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/https/upgrade-http/go.mod
+++ b/examples/https/upgrade-http/go.mod
@@ -2,4 +2,4 @@ module github.com/sktylr/routeit/examples/https/upgrade-http
 
 go 1.24.4
 
-require github.com/sktylr/routeit v1.2.0
+require github.com/sktylr/routeit v1.2.1

--- a/examples/https/upgrade-http/go.sum
+++ b/examples/https/upgrade-http/go.sum
@@ -1,2 +1,2 @@
-github.com/sktylr/routeit v1.2.0 h1:lBhIJFyQNo9JI45bbXXARdhWz+CI14cZPs3v7aBNmbQ=
-github.com/sktylr/routeit v1.2.0/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=
+github.com/sktylr/routeit v1.2.1 h1:mmKsH77Q2gTAXzZKPU/1oAuKQnPGY+/cs5vpnk2BYJ0=
+github.com/sktylr/routeit v1.2.1/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/middleware/complex/go.mod
+++ b/examples/middleware/complex/go.mod
@@ -2,4 +2,4 @@ module github.com/sktylr/routeit/examples/middleware/complex
 
 go 1.24.4
 
-require github.com/sktylr/routeit v1.2.0
+require github.com/sktylr/routeit v1.2.1

--- a/examples/middleware/complex/go.sum
+++ b/examples/middleware/complex/go.sum
@@ -1,2 +1,2 @@
-github.com/sktylr/routeit v1.2.0 h1:lBhIJFyQNo9JI45bbXXARdhWz+CI14cZPs3v7aBNmbQ=
-github.com/sktylr/routeit v1.2.0/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=
+github.com/sktylr/routeit v1.2.1 h1:mmKsH77Q2gTAXzZKPU/1oAuKQnPGY+/cs5vpnk2BYJ0=
+github.com/sktylr/routeit v1.2.1/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/middleware/cors/go.mod
+++ b/examples/middleware/cors/go.mod
@@ -2,4 +2,4 @@ module github.com/sktylr/routeit/examples/middleware/cors
 
 go 1.24.4
 
-require github.com/sktylr/routeit v1.2.0
+require github.com/sktylr/routeit v1.2.1

--- a/examples/middleware/cors/go.sum
+++ b/examples/middleware/cors/go.sum
@@ -1,2 +1,2 @@
-github.com/sktylr/routeit v1.2.0 h1:lBhIJFyQNo9JI45bbXXARdhWz+CI14cZPs3v7aBNmbQ=
-github.com/sktylr/routeit v1.2.0/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=
+github.com/sktylr/routeit v1.2.1 h1:mmKsH77Q2gTAXzZKPU/1oAuKQnPGY+/cs5vpnk2BYJ0=
+github.com/sktylr/routeit v1.2.1/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/middleware/simple/go.mod
+++ b/examples/middleware/simple/go.mod
@@ -2,4 +2,4 @@ module github.com/sktylr/routeit/examples/middleware/simple
 
 go 1.24.4
 
-require github.com/sktylr/routeit v1.2.0
+require github.com/sktylr/routeit v1.2.1

--- a/examples/middleware/simple/go.sum
+++ b/examples/middleware/simple/go.sum
@@ -1,2 +1,2 @@
-github.com/sktylr/routeit v1.2.0 h1:lBhIJFyQNo9JI45bbXXARdhWz+CI14cZPs3v7aBNmbQ=
-github.com/sktylr/routeit v1.2.0/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=
+github.com/sktylr/routeit v1.2.1 h1:mmKsH77Q2gTAXzZKPU/1oAuKQnPGY+/cs5vpnk2BYJ0=
+github.com/sktylr/routeit v1.2.1/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/routing/complex/go.mod
+++ b/examples/routing/complex/go.mod
@@ -2,4 +2,4 @@ module github.com/sktylr/routeit/examples/routing/complex
 
 go 1.24.4
 
-require github.com/sktylr/routeit v1.2.0
+require github.com/sktylr/routeit v1.2.1

--- a/examples/routing/complex/go.sum
+++ b/examples/routing/complex/go.sum
@@ -1,2 +1,2 @@
-github.com/sktylr/routeit v1.2.0 h1:lBhIJFyQNo9JI45bbXXARdhWz+CI14cZPs3v7aBNmbQ=
-github.com/sktylr/routeit v1.2.0/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=
+github.com/sktylr/routeit v1.2.1 h1:mmKsH77Q2gTAXzZKPU/1oAuKQnPGY+/cs5vpnk2BYJ0=
+github.com/sktylr/routeit v1.2.1/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/routing/dynamic/go.mod
+++ b/examples/routing/dynamic/go.mod
@@ -2,4 +2,4 @@ module github.com/sktylr/routeit/examples/routing/dynamic
 
 go 1.24.4
 
-require github.com/sktylr/routeit v1.2.0
+require github.com/sktylr/routeit v1.2.1

--- a/examples/routing/dynamic/go.sum
+++ b/examples/routing/dynamic/go.sum
@@ -1,2 +1,2 @@
-github.com/sktylr/routeit v1.2.0 h1:lBhIJFyQNo9JI45bbXXARdhWz+CI14cZPs3v7aBNmbQ=
-github.com/sktylr/routeit v1.2.0/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=
+github.com/sktylr/routeit v1.2.1 h1:mmKsH77Q2gTAXzZKPU/1oAuKQnPGY+/cs5vpnk2BYJ0=
+github.com/sktylr/routeit v1.2.1/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/routing/namespaced/go.mod
+++ b/examples/routing/namespaced/go.mod
@@ -2,4 +2,4 @@ module github.com/sktylr/routeit/examples/routing/namespaced
 
 go 1.24.4
 
-require github.com/sktylr/routeit v1.2.0
+require github.com/sktylr/routeit v1.2.1

--- a/examples/routing/namespaced/go.sum
+++ b/examples/routing/namespaced/go.sum
@@ -1,2 +1,2 @@
-github.com/sktylr/routeit v1.2.0 h1:lBhIJFyQNo9JI45bbXXARdhWz+CI14cZPs3v7aBNmbQ=
-github.com/sktylr/routeit v1.2.0/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=
+github.com/sktylr/routeit v1.2.1 h1:mmKsH77Q2gTAXzZKPU/1oAuKQnPGY+/cs5vpnk2BYJ0=
+github.com/sktylr/routeit v1.2.1/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/routing/simple/go.mod
+++ b/examples/routing/simple/go.mod
@@ -2,4 +2,4 @@ module github.com/sktylr/routeit/examples/routing/simple
 
 go 1.24.4
 
-require github.com/sktylr/routeit v1.2.0
+require github.com/sktylr/routeit v1.2.1

--- a/examples/routing/simple/go.sum
+++ b/examples/routing/simple/go.sum
@@ -1,2 +1,2 @@
-github.com/sktylr/routeit v1.2.0 h1:lBhIJFyQNo9JI45bbXXARdhWz+CI14cZPs3v7aBNmbQ=
-github.com/sktylr/routeit v1.2.0/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=
+github.com/sktylr/routeit v1.2.1 h1:mmKsH77Q2gTAXzZKPU/1oAuKQnPGY+/cs5vpnk2BYJ0=
+github.com/sktylr/routeit v1.2.1/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/simple/go.mod
+++ b/examples/simple/go.mod
@@ -2,4 +2,4 @@ module github.com/sktylr/routeit/examples/simple
 
 go 1.24.4
 
-require github.com/sktylr/routeit v1.2.0
+require github.com/sktylr/routeit v1.2.1

--- a/examples/simple/go.sum
+++ b/examples/simple/go.sum
@@ -1,2 +1,2 @@
-github.com/sktylr/routeit v1.2.0 h1:lBhIJFyQNo9JI45bbXXARdhWz+CI14cZPs3v7aBNmbQ=
-github.com/sktylr/routeit v1.2.0/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=
+github.com/sktylr/routeit v1.2.1 h1:mmKsH77Q2gTAXzZKPU/1oAuKQnPGY+/cs5vpnk2BYJ0=
+github.com/sktylr/routeit v1.2.1/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/static/rewrites/complex/go.mod
+++ b/examples/static/rewrites/complex/go.mod
@@ -2,4 +2,4 @@ module github.com/sktylr/routeit/examples/static/rewrites/complex
 
 go 1.24.4
 
-require github.com/sktylr/routeit v1.2.0
+require github.com/sktylr/routeit v1.2.1

--- a/examples/static/rewrites/complex/go.sum
+++ b/examples/static/rewrites/complex/go.sum
@@ -1,2 +1,2 @@
-github.com/sktylr/routeit v1.2.0 h1:lBhIJFyQNo9JI45bbXXARdhWz+CI14cZPs3v7aBNmbQ=
-github.com/sktylr/routeit v1.2.0/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=
+github.com/sktylr/routeit v1.2.1 h1:mmKsH77Q2gTAXzZKPU/1oAuKQnPGY+/cs5vpnk2BYJ0=
+github.com/sktylr/routeit v1.2.1/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/static/rewrites/dynamic/go.mod
+++ b/examples/static/rewrites/dynamic/go.mod
@@ -2,4 +2,4 @@ module github.com/sktylr/routeit/examples/static/rewrites/dynamic
 
 go 1.24.4
 
-require github.com/sktylr/routeit v1.2.0
+require github.com/sktylr/routeit v1.2.1

--- a/examples/static/rewrites/dynamic/go.sum
+++ b/examples/static/rewrites/dynamic/go.sum
@@ -1,2 +1,2 @@
-github.com/sktylr/routeit v1.2.0 h1:lBhIJFyQNo9JI45bbXXARdhWz+CI14cZPs3v7aBNmbQ=
-github.com/sktylr/routeit v1.2.0/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=
+github.com/sktylr/routeit v1.2.1 h1:mmKsH77Q2gTAXzZKPU/1oAuKQnPGY+/cs5vpnk2BYJ0=
+github.com/sktylr/routeit v1.2.1/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/static/rewrites/static/go.mod
+++ b/examples/static/rewrites/static/go.mod
@@ -2,4 +2,4 @@ module github.com/sktylr/routeit/examples/static/rewrites/static
 
 go 1.24.4
 
-require github.com/sktylr/routeit v1.2.0
+require github.com/sktylr/routeit v1.2.1

--- a/examples/static/rewrites/static/go.sum
+++ b/examples/static/rewrites/static/go.sum
@@ -1,2 +1,2 @@
-github.com/sktylr/routeit v1.2.0 h1:lBhIJFyQNo9JI45bbXXARdhWz+CI14cZPs3v7aBNmbQ=
-github.com/sktylr/routeit v1.2.0/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=
+github.com/sktylr/routeit v1.2.1 h1:mmKsH77Q2gTAXzZKPU/1oAuKQnPGY+/cs5vpnk2BYJ0=
+github.com/sktylr/routeit v1.2.1/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/static/simple/go.mod
+++ b/examples/static/simple/go.mod
@@ -2,4 +2,4 @@ module github.com/sktylr/routeit/examples/static/simple
 
 go 1.24.4
 
-require github.com/sktylr/routeit v1.2.0
+require github.com/sktylr/routeit v1.2.1

--- a/examples/static/simple/go.sum
+++ b/examples/static/simple/go.sum
@@ -1,2 +1,2 @@
-github.com/sktylr/routeit v1.2.0 h1:lBhIJFyQNo9JI45bbXXARdhWz+CI14cZPs3v7aBNmbQ=
-github.com/sktylr/routeit v1.2.0/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=
+github.com/sktylr/routeit v1.2.1 h1:mmKsH77Q2gTAXzZKPU/1oAuKQnPGY+/cs5vpnk2BYJ0=
+github.com/sktylr/routeit v1.2.1/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=

--- a/examples/todo/go.mod
+++ b/examples/todo/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/google/uuid v1.6.0
 	github.com/mattn/go-sqlite3 v1.14.30
-	github.com/sktylr/routeit v1.2.0
+	github.com/sktylr/routeit v1.2.1
 	github.com/sktylr/routeit/requestid v0.1.0
 	golang.org/x/crypto v0.40.0
 )

--- a/examples/todo/go.sum
+++ b/examples/todo/go.sum
@@ -11,8 +11,8 @@ github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/mattn/go-sqlite3 v1.14.30 h1:bVreufq3EAIG1Quvws73du3/QgdeZ3myglJlrzSYYCY=
 github.com/mattn/go-sqlite3 v1.14.30/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
-github.com/sktylr/routeit v1.2.0 h1:lBhIJFyQNo9JI45bbXXARdhWz+CI14cZPs3v7aBNmbQ=
-github.com/sktylr/routeit v1.2.0/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=
+github.com/sktylr/routeit v1.2.1 h1:mmKsH77Q2gTAXzZKPU/1oAuKQnPGY+/cs5vpnk2BYJ0=
+github.com/sktylr/routeit v1.2.1/go.mod h1:EZOD7GOrqszUM3TES5VL8oSmFxa2t6yYQXPVaNxswE0=
 github.com/sktylr/routeit/requestid v0.1.0 h1:rmg0xjEtvTZQxy2fMxCZe+zHpfXOZimblMMhZA7M5sU=
 github.com/sktylr/routeit/requestid v0.1.0/go.mod h1:FB6ywa1IdpWmbcklrFQPFXpJFUoNMEwNhiEx38xJTUU=
 golang.org/x/crypto v0.40.0 h1:r4x+VvoG5Fm+eJcxMaY8CQM7Lb0l1lsmjGBQ6s8BfKM=


### PR DESCRIPTION
### Summary
<!-- A high level summary of the changes, including any gotchas that the reviewer should watch out for when reviewing. -->

Bumps the examples to v1.2.1 since it has now been released.
---
Bumped:
- ./https/both
- ./https/upgrade-http
- ./https/https-only
- ./middleware/complex
- ./middleware/simple
- ./middleware/cors
- ./simple
- ./todo
- ./static/rewrites/dynamic
- ./static/rewrites/complex
- ./static/rewrites/static
- ./static/simple
- ./routing/namespaced
- ./routing/dynamic
- ./routing/complex
- ./routing/simple
- ./errors/mapping
- ./errors/handling

### Motivation
<!-- Why is this change necessary? This can be a link to a GitHub issue or reproduction steps for a bug etc. -->

Keep examples up to date.

### Test plan
<!-- How did you test the changes? Are there edge cases you are missing or were unable to test? -->

- [x] Existing E2E tests
- [x] Local verification
